### PR TITLE
Fix of parent window detection in Debug build

### DIFF
--- a/Asn1Editor/API/Utils/WPF/WindowFactoryBase.cs
+++ b/Asn1Editor/API/Utils/WPF/WindowFactoryBase.cs
@@ -7,16 +7,11 @@ namespace SysadminsLV.Asn1Editor.API.Utils.WPF {
         void setParent(Boolean mainWindowAsParent = false) {
             WindowCollection windows = Application.Current.Windows;
             Window parent = null;
-            if (windows.Count > 0) {
-                if (mainWindowAsParent) {
-                    parent = windows[0];
-                } else {
-#if DEBUG
-                    parent = windows[windows.Count - 3];
-#else
-                    parent = windows[windows.Count - 2];
-#endif
-                }
+            if (windows.Count > 0)
+            {
+                parent = mainWindowAsParent 
+                    ? windows[0] 
+                    : windows[windows.Count - 2];
             }
             hwnd.Owner = parent;
         }


### PR DESCRIPTION
I don't know why it's written like this, but it doesn't work in Debug build configuration. The whole app crashing with the "Index was out of range" error when trying to open any new window.

Log:
```
******************************** Started ********************************
Process: Asn1Editor
PID    : 20792
Version: 1.4.2.0
[13-08-2021 16:04:32] An exception has been thrown:
	Error message: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
	Stack trace:
		at System.Collections.ArrayList.get_Item(Int32 index)
		at System.Windows.WindowCollection.get_Item(Int32 index)
		at SysadminsLV.Asn1Editor.API.Utils.WPF.WindowFactoryBase.setParent(Boolean mainWindowAsParent) in C:\git\learn\demos\Asn1Editor.WPF\Asn1Editor\API\Utils\WPF\WindowFactoryBase.cs:line 15
		at SysadminsLV.Asn1Editor.API.Utils.WPF.WindowFactoryBase.ShowAsDialog() in C:\git\learn\demos\Asn1Editor.WPF\Asn1Editor\API\Utils\WPF\WindowFactoryBase.cs:line 28
		at SysadminsLV.Asn1Editor.API.Utils.WPF.WindowFactory.ShowLicenseDialog() in C:\git\learn\demos\Asn1Editor.WPF\Asn1Editor\API\Utils\WPF\WindowFactory.cs:line 16
		at SysadminsLV.Asn1Editor.API.ViewModel.AppCommands.showLicense(Object o) in C:\git\learn\demos\Asn1Editor.WPF\Asn1Editor\API\ViewModel\AppCommands.cs:line 24
		at MS.Internal.Commands.CommandHelpers.CriticalExecuteCommandSource(ICommandSource commandSource, Boolean userInitiated)
		at System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
		at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
		at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```