### PR TITLE
downgraded from .NET 4.8 to .NET 4.7.2 for better compatibility

### DIFF
--- a/Asn1Editor.Wpf.Controls/Asn1Editor.Wpf.Controls.csproj
+++ b/Asn1Editor.Wpf.Controls/Asn1Editor.Wpf.Controls.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Asn1Editor.Wpf.Controls</RootNamespace>
     <AssemblyName>Asn1Editor.Wpf.Controls</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Asn1Editor/App.config
+++ b/Asn1Editor/App.config
@@ -6,7 +6,7 @@
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
     <userSettings>
         <SysadminsLV.Asn1Editor.Properties.Settings>

--- a/Asn1Editor/Asn1Editor.csproj
+++ b/Asn1Editor/Asn1Editor.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>SysadminsLV.Asn1Editor</RootNamespace>
     <AssemblyName>Asn1Editor</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Asn1Editor/Properties/Settings.Designer.cs
+++ b/Asn1Editor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SysadminsLV.Asn1Editor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
during project upgrade in Visual Studio it was mistakenly upgraded to .NET 4.8. We get no benefits from .NET 4.8 and downgraded to .NET 4.7.2 to have larger OS range support.