### PR TITLE
Created AutoSizeTextBox

### DIFF
--- a/Asn1Editor.Wpf.Controls/Asn1Editor.Wpf.Controls.csproj
+++ b/Asn1Editor.Wpf.Controls/Asn1Editor.Wpf.Controls.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsnHexViewer.cs" />
+    <Compile Include="AutoSizeTextBox.cs" />
     <Compile Include="BusyIndicator.xaml.cs">
       <DependentUpon>BusyIndicator.xaml</DependentUpon>
     </Compile>

--- a/Asn1Editor.Wpf.Controls/AsnHexViewer.cs
+++ b/Asn1Editor.Wpf.Controls/AsnHexViewer.cs
@@ -270,8 +270,8 @@ public class AsnHexViewer : Control {
         ranges = new TextRange[3];
         calculateWidths();
         panes = [HexAddressPane, HexRawPane, HexAsciiPane];
-        refreshView();
         controlInitialized = true;
+        refreshView();
         if (SelectedNode is not null) {
             reColorHex(SelectedNode);
         }

--- a/Asn1Editor.Wpf.Controls/AsnHexViewer.cs
+++ b/Asn1Editor.Wpf.Controls/AsnHexViewer.cs
@@ -142,9 +142,9 @@ public class AsnHexViewer : Control {
     #endregion
 
     void calculateWidths() {
-        HexAddrHeaderRtb.MeasureStringWidth(masterAddr, FontSize, false);
-        HexRawHeaderRtb.MeasureStringWidth(masterHex, FontSize, false);
-        HexAsciiHeaderRtb.MeasureStringWidth(masterAscii, FontSize, false);
+        HexAddrHeaderRtb.MeasureStringWidth(masterAddr);
+        HexRawHeaderRtb.MeasureStringWidth(masterHex);
+        HexAsciiHeaderRtb.MeasureStringWidth(masterAscii);
     }
     void buildAddress() {
         HexAddressPane.Document = new FlowDocument();

--- a/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
+++ b/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
@@ -36,6 +36,6 @@ public class AutoSizeTextBox : TextBox {
     }
 
     void recalculateWidth() {
-        this.MeasureStringWidth(new String('0', LineWidth));
+        this.MeasureStringWidth(new String('M', LineWidth));
     }
 }

--- a/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
+++ b/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
@@ -36,6 +36,6 @@ public class AutoSizeTextBox : TextBox {
     }
 
     void recalculateWidth() {
-        this.MeasureStringWidth(new String('0', LineWidth), FontSize, AcceptsReturn);
+        this.MeasureStringWidth(new String('0', LineWidth));
     }
 }

--- a/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
+++ b/Asn1Editor.Wpf.Controls/AutoSizeTextBox.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using Asn1Editor.Wpf.Controls.Helpers;
+
+namespace Asn1Editor.Wpf.Controls;
+
+/// <summary>
+/// Represents a textbox control that can set its width to fit exact number of characters.
+/// </summary>
+public class AutoSizeTextBox : TextBox {
+    static AutoSizeTextBox() {
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(AutoSizeTextBox),
+            new FrameworkPropertyMetadata(typeof(AutoSizeTextBox)));
+        FontSizeProperty.OverrideMetadata(typeof(AutoSizeTextBox),
+            new FrameworkPropertyMetadata(OnFontSizeChanged));
+    }
+
+    static void OnFontSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        ((AutoSizeTextBox)d).recalculateWidth();
+    }
+
+    public static readonly DependencyProperty LineWidthProperty = DependencyProperty.Register(
+        nameof(LineWidth),
+        typeof(Int32),
+        typeof(AutoSizeTextBox),
+        new PropertyMetadata(0, onLineWidthChanged));
+    static void onLineWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        ((AutoSizeTextBox)d).recalculateWidth();
+    }
+
+    public Int32 LineWidth {
+        get => (Int32)GetValue(LineWidthProperty);
+        set => SetValue(LineWidthProperty, value);
+    }
+
+    void recalculateWidth() {
+        this.MeasureStringWidth(new String('0', LineWidth), FontSize, AcceptsReturn);
+    }
+}

--- a/Asn1Editor.Wpf.Controls/Helpers/TextBoxBaseExtensions.cs
+++ b/Asn1Editor.Wpf.Controls/Helpers/TextBoxBaseExtensions.cs
@@ -6,16 +6,22 @@ using System.Windows.Media;
 
 namespace Asn1Editor.Wpf.Controls.Helpers;
 static class TextBoxBaseExtensions {
-    public static void MeasureStringWidth(this TextBoxBase textBoxBase, String str, Double size, Boolean includeScrollbars) {
+    /// <summary>
+    /// Sets <see cref="TextBoxBase"/> control's width to a value required to fit requested text string.
+    /// </summary>
+    /// <param name="textBoxBase">A <see cref="TextBoxBase"/> instance that defines font style.</param>
+    /// <param name="str">String to fit.</param>
+    public static void MeasureStringWidth(this TextBoxBase textBoxBase, String str) {
         FormattedText formattedText = new FormattedText(
             str,
             CultureInfo.CurrentUICulture,
             FlowDirection.LeftToRight,
-            new Typeface(new FontFamily("Consolas"), FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
-            size, Brushes.Black,
+            new Typeface(textBoxBase.FontFamily, textBoxBase.FontStyle, textBoxBase.FontWeight, textBoxBase.FontStretch),
+            textBoxBase.FontSize,
+            textBoxBase.Foreground,
             VisualTreeHelper.GetDpi(textBoxBase).PixelsPerDip);
 
-        textBoxBase.Width = includeScrollbars
+        textBoxBase.Width = textBoxBase.AcceptsReturn
             ? formattedText.Width + SystemParameters.VerticalScrollBarWidth + 12
             : formattedText.Width + 12;
     }

--- a/Asn1Editor.Wpf.Controls/Helpers/TextUtility.cs
+++ b/Asn1Editor.Wpf.Controls/Helpers/TextUtility.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
 using SysadminsLV.WPF.OfficeTheme.Controls;
 
-namespace Asn1Editor.Wpf.Controls.Helpers; 
+namespace Asn1Editor.Wpf.Controls.Helpers;
 
 public static class TextUtility {
     static Int32 getOffset(Int32 offset) {
@@ -60,17 +59,5 @@ public static class TextUtility {
         foreach (TextRange range in ranges.Where(range => range != null)) {
             range.ClearAllProperties();
         }
-    }
-    public static Double MeasureStringWidth(String str, Double size, Boolean includeScrollbars) {
-        var formattedText = new FormattedText(
-            str,
-            CultureInfo.CurrentUICulture,
-            FlowDirection.LeftToRight,
-            new Typeface(new FontFamily("Consolas"), FontStyles.Normal, FontWeights.Normal, FontStretches.Normal),
-            size,
-            Brushes.Black);
-        return includeScrollbars
-            ? formattedText.Width + SystemParameters.VerticalScrollBarWidth + 12
-            : formattedText.Width + 12;
     }
 }

--- a/Asn1Editor.Wpf.Controls/Themes/Generic.xaml
+++ b/Asn1Editor.Wpf.Controls/Themes/Generic.xaml
@@ -1,5 +1,10 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Asn1Editor.Wpf.Controls">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Asn1Editor.Wpf.Controls;component/Themes/AsnHexViewerControl.xaml"/>
     </ResourceDictionary.MergedDictionaries>
+    <Style TargetType="controls:AutoSizeTextBox" BasedOn="{StaticResource {x:Type TextBoxBase}}">
+        <Setter Property="Background" Value="White"/>
+    </Style>
 </ResourceDictionary>

--- a/Asn1Editor/API/ViewModel/NewAsnNodeEditorVM.cs
+++ b/Asn1Editor/API/ViewModel/NewAsnNodeEditorVM.cs
@@ -2,7 +2,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
-using Asn1Editor.Wpf.Controls.Helpers;
 using SysadminsLV.Asn1Editor.API.Abstractions;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
@@ -11,10 +10,6 @@ using SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
 public class NewAsnNodeEditorVM : ClosableWindowVM, INewAsnNodeEditorVM {
-    const String masterTag = "123";
-
-    Double tagTextBoxWidth;
-
     Boolean shouldGenerateNode;
     Boolean formTagChecked, decimalTagChecked, hexTagChecked,
         clsConstructedChecked, clsSpecificChecked, clsApplicationChecked, clsPrivateChecked;
@@ -23,7 +18,6 @@ public class NewAsnNodeEditorVM : ClosableWindowVM, INewAsnNodeEditorVM {
 
     public NewAsnNodeEditorVM(NodeViewOptions options) {
         NodeViewOptions = options;
-        TagTextBoxWidth = TextUtility.MeasureStringWidth(masterTag, options.FontSize, false);
         formTagChecked = true;
         OkCommand = new RelayCommand(save, canSave);
         selectedType = Asn1Type.SEQUENCE;
@@ -147,14 +141,6 @@ public class NewAsnNodeEditorVM : ClosableWindowVM, INewAsnNodeEditorVM {
         set {
             resultTagName = value;
             OnPropertyChanged(nameof(ResultTagName));
-        }
-    }
-
-    public Double TagTextBoxWidth {
-        get => tagTextBoxWidth;
-        set {
-            tagTextBoxWidth = value;
-            OnPropertyChanged(nameof(TagTextBoxWidth));
         }
     }
 

--- a/Asn1Editor/API/ViewModel/TagDataEditorVM.cs
+++ b/Asn1Editor/API/ViewModel/TagDataEditorVM.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
-using Asn1Editor.Wpf.Controls.Helpers;
 using SysadminsLV.Asn1Editor.API.Abstractions;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
@@ -17,14 +16,12 @@ namespace SysadminsLV.Asn1Editor.API.ViewModel;
 class TagDataEditorVM : ViewModelBase, ITagDataEditorVM {
     readonly IUIMessenger _uiMessenger;
     readonly IDataSource _data;
-    const String masterUnused = "1";
     NodeEditMode mode;
     Boolean? dialogResult;
     String tagDetails;
     AsnViewValue tagValue, oldValue;
     Boolean rbText = true, rbHex, isReadonly;
     Byte unusedBits;
-    Double unusedTextBoxWidth;
 
 
     public TagDataEditorVM(IHasAsnDocumentTabs appTabs, IUIMessenger uiMessenger) {
@@ -75,13 +72,6 @@ class TagDataEditorVM : ViewModelBase, ITagDataEditorVM {
         }
     }
     public Boolean IsEditable => !IsReadOnly;
-    public Double UnusedTextBoxWidth {
-        get => unusedTextBoxWidth;
-        set {
-            unusedTextBoxWidth = value;
-            OnPropertyChanged(nameof(UnusedTextBoxWidth));
-        }
-    }
     public Boolean RbText {
         get => rbText;
         set {
@@ -119,15 +109,6 @@ class TagDataEditorVM : ViewModelBase, ITagDataEditorVM {
 
     void initialize() {
         tagValue = new AsnViewValue();
-        calculateLengths();
-        Settings.Default.PropertyChanged += (Sender, Args) => {
-            if (Args.PropertyName == nameof(Settings.FontSize)) {
-                calculateLengths();
-            }
-        };
-    }
-    void calculateLengths() {
-        UnusedTextBoxWidth = TextUtility.MeasureStringWidth(masterUnused, Settings.Default.FontSize, false);
     }
     void submitValues(Object obj) {
         if (Equals(TagValue, oldValue)) {

--- a/Asn1Editor/API/ViewModel/TextViewerVM.cs
+++ b/Asn1Editor/API/ViewModel/TextViewerVM.cs
@@ -2,12 +2,10 @@
 using System.Globalization;
 using System.IO;
 using System.Windows.Input;
-using Asn1Editor.Wpf.Controls.Helpers;
 using SysadminsLV.Asn1Editor.API.Abstractions;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.Utils;
-using SysadminsLV.Asn1Editor.Properties;
 using SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
@@ -25,15 +23,14 @@ class TextViewerVM : ViewModelBase, ITextViewerVM {
     String text;
     Int32 currentLength = 80;
     String currentLengthStr = "80";
-    Double width;
 
-    public TextViewerVM(IHasAsnDocumentTabs appTabs, IUIMessenger uiMessenger) {
+    public TextViewerVM(IHasAsnDocumentTabs appTabs, NodeViewOptions options, IUIMessenger uiMessenger) {
         rootNode = appTabs.SelectedTab.DataSource.SelectedNode;
+        NodeViewOptions = options;
         CurrentLength = defaultLength.ToString(CultureInfo.InvariantCulture);
         SaveCommand = new RelayCommand(saveFile);
         PrintCommand = new RelayCommand(print);
         ApplyCommand = new RelayCommand(applyNewLength);
-        TextBoxWidth = TextUtility.MeasureStringWidth(master, Settings.Default.FontSize, false);
         CertutilViewChecked = true;
         renderer.RenderText(currentLength);
         _uiMessenger = uiMessenger;
@@ -41,7 +38,9 @@ class TextViewerVM : ViewModelBase, ITextViewerVM {
 
     public ICommand SaveCommand { get; set; }
     public ICommand PrintCommand { get; set; }
-    public ICommand ApplyCommand { get; set; }
+    public ICommand ApplyCommand { get; }
+
+    public NodeViewOptions NodeViewOptions { get; }
 
     public String Text {
         get => text;
@@ -55,13 +54,6 @@ class TextViewerVM : ViewModelBase, ITextViewerVM {
         set {
             currentLengthStr = value;
             OnPropertyChanged(nameof(CurrentLength));
-        }
-    }
-    public Double TextBoxWidth {
-        get => width;
-        set {
-            width = value;
-            OnPropertyChanged(nameof(TextBoxWidth));
         }
     }
     public Boolean CertutilViewChecked {

--- a/Asn1Editor/Views/UserControls/NewTreeNodeFormUC.xaml
+++ b/Asn1Editor/Views/UserControls/NewTreeNodeFormUC.xaml
@@ -7,6 +7,7 @@
              xmlns:asn1Parser="clr-namespace:SysadminsLV.Asn1Parser;assembly=SysadminsLV.Asn1Parser"
              xmlns:vm="clr-namespace:SysadminsLV.Asn1Editor.API.ViewModel"
              xmlns:behaviors="clr-namespace:SysadminsLV.WPF.OfficeTheme.Toolkit.Behaviors;assembly=Wpf.OfficeTheme"
+             xmlns:c="clr-namespace:Asn1Editor.Wpf.Controls;assembly=Asn1Editor.Wpf.Controls"
              d:DataContext="{d:DesignInstance vm:NewAsnNodeEditorVM}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
@@ -51,9 +52,9 @@
         <Grid IsEnabled="{Binding ElementName=TextDecRadio, Path=IsChecked}">
             <StackPanel Margin="20,0,0,0" Orientation="Horizontal">
                 <TextBlock Text="Tag number (1-255): "/>
-                <TextBox Width="{Binding TagTextBoxWidth}"
-                         MaxLength="3"
-                         Text="{Binding DecimalTagText, UpdateSourceTrigger=PropertyChanged}"/>
+                <c:AutoSizeTextBox MaxLength="3"
+                                   LineWidth="3"
+                                   Text="{Binding DecimalTagText, UpdateSourceTrigger=PropertyChanged}"/>
             </StackPanel>
         </Grid>
         
@@ -66,9 +67,9 @@
             <StackPanel Margin="20,0,0,0"
                                 Orientation="Horizontal">
                 <TextBlock Text="Tag number (1-FF): "/>
-                <TextBox Width="{Binding TagTextBoxWidth}"
-                             MaxLength="2"
-                             Text="{Binding HexTagText, UpdateSourceTrigger=PropertyChanged}"/>
+                <c:AutoSizeTextBox MaxLength="2"
+                                   LineWidth="2"
+                                   Text="{Binding HexTagText, UpdateSourceTrigger=PropertyChanged}"/>
             </StackPanel>
         </Grid>
 

--- a/Asn1Editor/Views/Windows/TagDataEditor.xaml
+++ b/Asn1Editor/Views/Windows/TagDataEditor.xaml
@@ -6,6 +6,7 @@
         xmlns:cmd="clr-namespace:SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;assembly=Wpf.OfficeTheme"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:controls="clr-namespace:Asn1Editor.Wpf.Controls;assembly=Asn1Editor.Wpf.Controls"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance vm:TagDataEditorVM}"
         cmd:DialogCloser.DialogResult="{Binding DialogResult}"
@@ -46,8 +47,8 @@
                             Visibility="{Binding UnusedBitsVisible, Converter={StaticResource BooleanToVisibility}}">
                     <TextBlock Text="Unused bits:"
                                VerticalAlignment="Center" Margin="2,0"/>
-                    <TextBox Text="{Binding UnusedBits}"
-                             Width="{Binding UnusedTextBoxWidth}"
+                    <controls:AutoSizeTextBox Text="{Binding UnusedBits}"
+                             LineWidth="1"
                              MaxLength="1"
                              FontFamily="Consolas"/>
                 </StackPanel>

--- a/Asn1Editor/Views/Windows/TextViewer.xaml
+++ b/Asn1Editor/Views/Windows/TextViewer.xaml
@@ -2,13 +2,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:SysadminsLV.Asn1Editor.API.ViewModel"
-        xmlns:properties="clr-namespace:SysadminsLV.Asn1Editor.Properties"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:c="clr-namespace:Asn1Editor.Wpf.Controls;assembly=Asn1Editor.Wpf.Controls"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance vm:TextViewerVM}"
         WindowStartupLocation="CenterOwner"
         Title="ASN.1 Text Dump Viewer"
+        FontSize="{Binding NodeViewOptions.FontSize, Mode=OneTime}"
         Height="600"
         Width="800">
     <Window.InputBindings>
@@ -53,20 +54,18 @@
                              Style="{StaticResource {x:Type RadioButton}}"/>
             </ToolBar>
         </ToolBarTray>
-        <StatusBar DockPanel.Dock="Bottom">
+        <StatusBar DockPanel.Dock="Bottom" FontSize="{Binding NodeViewOptions.FontSize, Mode=OneTime}">
             <StatusBarItem>
                 <TextBlock Text="Line width (characters): "/>
             </StatusBarItem>
             <StatusBarItem IsEnabled="{Binding OpenSSLViewChecked}">
-                <TextBox Text="{Binding CurrentLength, UpdateSourceTrigger=PropertyChanged}"
-                         Width="{Binding TextBoxWidth}"
-                         Background="White"
-                         UndoLimit="0"
-                         IsUndoEnabled="False"
-                         FontFamily="Consolas"
-                         Foreground="Navy"
-                         FontSize="{Binding Path=FontSize, Source={x:Static properties:Settings.Default}}"
-                         MaxLength="3"/>
+                <c:AutoSizeTextBox Text="{Binding CurrentLength, UpdateSourceTrigger=PropertyChanged}"
+                                   UndoLimit="0"
+                                   IsUndoEnabled="False"
+                                   FontFamily="Consolas"
+                                   Foreground="Navy"
+                                   LineWidth="3"
+                                   MaxLength="3"/>
             </StatusBarItem>
             <StatusBarItem IsEnabled="{Binding OpenSSLViewChecked}">
                 <Button Content="Apply" Command="{Binding ApplyCommand}" MinWidth="50"/>
@@ -79,7 +78,6 @@
         <TextBox Text="{Binding Text}"
                  UndoLimit="10"
                  FontFamily="Consolas"
-                 FontSize="{Binding Path=FontSize, Source={x:Static properties:Settings.Default}}"
                  HorizontalScrollBarVisibility="Auto"
                  VerticalScrollBarVisibility="Auto"/>
     </DockPanel>


### PR DESCRIPTION
Added new `AutoSizeTextBox` control which can autosize its width to fit text of specified number of characters.

This allowed to remove silly TextBoxWidth properties in view models and UI-specific APIs.