### PR TITLE
Improved long-running actions UI handling

### DIFF
--- a/Asn1Editor.Wpf.Controls/Themes/BusyIndicator.xaml
+++ b/Asn1Editor.Wpf.Controls/Themes/BusyIndicator.xaml
@@ -14,7 +14,8 @@
                     Opacity="1"
                     Background="White"
                     VerticalAlignment="Center"
-                    HorizontalAlignment="Center">
+                    HorizontalAlignment="Center"
+                    MinWidth="200">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/Asn1Editor.Wpf.Controls/Themes/BusyIndicator.xaml
+++ b/Asn1Editor.Wpf.Controls/Themes/BusyIndicator.xaml
@@ -21,18 +21,18 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="40"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:BusyIndicator}}, Path=HeaderText}"
+                    <TextBlock Text="{TemplateBinding HeaderText}"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"
                                FontSize="16"
                                Margin="10,0"/>
                     <TextBlock Grid.Row="1"
-                               Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:BusyIndicator}}, Path=Text}"
+                               Text="{TemplateBinding Text}"
                                Margin="10,0,0,0"/>
                     <ProgressBar Grid.Row="2"
                                  Margin="10"
-                                 IsIndeterminate="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:BusyIndicator}}, Path=IsIndeterminate}"
-                                 Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:BusyIndicator}}, Path=ProgressValue}"/>
+                                 IsIndeterminate="{TemplateBinding IsIndeterminate}"
+                                 Value="{TemplateBinding ProgressValue}"/>
                 </Grid>
             </Border>
         </Grid>

--- a/Asn1Editor/API/Abstractions/IHasAsnDocumentTabs.cs
+++ b/Asn1Editor/API/Abstractions/IHasAsnDocumentTabs.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.ViewModel;
 
@@ -8,5 +10,5 @@ public interface IHasAsnDocumentTabs {
     NodeViewOptions NodeViewOptions { get; }
     Asn1DocumentVM SelectedTab { get; }
 
-    Task RefreshTabs();
+    Task RefreshTabs(Func<Asn1TreeNode, Boolean>? filter = null);
 }

--- a/Asn1Editor/API/Abstractions/IHasAsnDocumentTabs.cs
+++ b/Asn1Editor/API/Abstractions/IHasAsnDocumentTabs.cs
@@ -1,4 +1,5 @@
-﻿using SysadminsLV.Asn1Editor.API.ModelObjects;
+﻿using System.Threading.Tasks;
+using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.ViewModel;
 
 namespace SysadminsLV.Asn1Editor.API.Abstractions;
@@ -7,5 +8,5 @@ public interface IHasAsnDocumentTabs {
     NodeViewOptions NodeViewOptions { get; }
     Asn1DocumentVM SelectedTab { get; }
 
-    void RefreshTabs();
+    Task RefreshTabs();
 }

--- a/Asn1Editor/API/Interfaces/IDataSource.cs
+++ b/Asn1Editor/API/Interfaces/IDataSource.cs
@@ -44,4 +44,9 @@ public interface IDataSource : IBinarySource {
     /// Resets current data source, which clears tree, backing binary source and sets <see cref="SelectedNode"/> to <c>null</c>.
     /// </summary>
     void Reset();
+
+    /// <summary>
+    /// Raised when tree refresh required.
+    /// </summary>
+    event EventHandler RequireTreeRefresh;
 }

--- a/Asn1Editor/API/ModelObjects/Asn1Lite.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1Lite.cs
@@ -12,11 +12,10 @@ using SysadminsLV.Asn1Parser;
 namespace SysadminsLV.Asn1Editor.API.ModelObjects;
 
 public class Asn1Lite : ViewModelBase, IHexAsnNode {
-    Byte tag, unusedBits;
+    Byte tag;
     Boolean invalidData;
     Int32 offset, offsetChange;
-    Int32 payloadLength, depth;
-    String header, toolTip, tagName, explicitValue, treePath;
+    String header, toolTip;
 
     public Asn1Lite(Asn1Reader asn) {
         initialize(asn);
@@ -34,19 +33,6 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
         }
     }
 
-    public String Caption {
-        get {
-            String value = String.IsNullOrEmpty(explicitValue) || !Settings.Default.DecodePayload
-                ? String.Empty
-                : " : " + explicitValue;
-            String value2 = IsContainer && Tag == (Byte)Asn1Type.BIT_STRING
-                ? " Unused bits: " + UnusedBits
-                : String.Empty;
-            return IsContainer
-                ? $"({Offset}, {PayloadLength}) {TagName}{value2.TrimEnd()}"
-                : $"({Offset}, {PayloadLength}) {TagName}{value.TrimEnd()}";
-        }
-    }
     public String Header {
         get => header;
         private set {
@@ -71,28 +57,14 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
             OnPropertyChanged();
         }
     }
-    public Byte UnusedBits {
-        get => unusedBits;
-        set {
-            unusedBits = value;
-            OnPropertyChanged();
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
-    public String TagName {
-        get => tagName;
-        private set {
-            tagName = value;
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
+    public Byte UnusedBits { get; set; }
+    public String TagName { get;  private set; }
     public Int32 Offset {
         get => offset;
         set {
             Int32 diff = value - offset;
             offset = value;
             PayloadStartOffset += diff;
-            OnPropertyChanged(nameof(Caption));
         }
     }
     public Int32 OffsetChange {
@@ -106,13 +78,7 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
 
     public Int32 PayloadStartOffset { get; set; }
     public Int32 HeaderLength => PayloadStartOffset - Offset;
-    public Int32 PayloadLength {
-        get => payloadLength;
-        set {
-            payloadLength = value;
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
+    public Int32 PayloadLength { get; set; }
     public Int32 TagLength => HeaderLength + PayloadLength;
     public Boolean IsContainer { get; set; }
     public Boolean IsContextSpecific { get; private set; }
@@ -123,27 +89,9 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
             OnPropertyChanged();
         }
     } //TODO
-    public Int32 Depth {
-        get => depth;
-        set {
-            depth = value;
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
-    public String Path {
-        get => treePath;
-        set {
-            treePath = value;
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
-    public String ExplicitValue {
-        get => explicitValue;
-        set {
-            explicitValue = value;
-            OnPropertyChanged(nameof(Caption));
-        }
-    }
+    public Int32 Depth { get; set; }
+    public String Path { get; set; }
+    public String ExplicitValue { get; set; }
 
     void initialize(Asn1Reader asn) {
         Offset = asn.Offset;

--- a/Asn1Editor/API/ModelObjects/Asn1Lite.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1Lite.cs
@@ -161,8 +161,24 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
         }
     }
 
-
+    /// <summary>
+    /// Performs node header update. This method does not perform expensive display value (except for
+    /// <strong>INTEGER</strong> and <strong>OBJECT_IDENTIFIER</strong> tags) or tooltip (all tags)
+    /// re-calculation and do not raise <see cref="DataChanged"/> event.
+    /// </summary>
+    /// <param name="rawData">Node raw data.</param>
+    /// <param name="options">Node view options.</param>
+    /// <remarks></remarks>
     public void UpdateNodeHeader(IReadOnlyList<Byte> rawData, NodeViewOptions options) {
+        Header = getNodeHeader(rawData, options);
+    }
+    /// <summary>
+    /// Performs node value update, which includes update for <see cref="Header"/>, <see cref="ToolTip"/>
+    /// and raises <see cref="DataChanged"/> event.
+    /// </summary>
+    /// <param name="rawData">Node raw data.</param>
+    /// <param name="options">Node view options.</param>
+    public void UpdateNode(IReadOnlyList<Byte> rawData, NodeViewOptions options) {
         Header = getNodeHeader(rawData, options);
         ToolTip = getToolTip(rawData);
         DataChanged?.Invoke(this, EventArgs.Empty);
@@ -174,8 +190,11 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
         if (Tag == (Byte)Asn1Type.OBJECT_IDENTIFIER) {
             updateOidValue(rawData);
         }
-        var outerList = new List<String>();
+
+        // contains only node location information, such as offset, length, path. Everything what is displayed in parentheses.
         var innerList = new List<String>();
+        // contains full node header, including inner list (see above), tag name and optional tag display value.
+        var outerList = new List<String>();
         if (options.ShowNodePath) {
             outerList.Add($"({Path})");
         }
@@ -273,5 +292,8 @@ public class Asn1Lite : ViewModelBase, IHexAsnNode {
     }
     #endregion
 
+    /// <summary>
+    /// Raised when node value changes. It is used by Hex Viewer to update node coloring boundaries.
+    /// </summary>
     public event EventHandler DataChanged;
 }

--- a/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
@@ -113,14 +113,16 @@ public class Asn1TreeNode : INotifyPropertyChanged {
         return _dataSource;
     }
 
-    public void UpdateNodeView() {
-        updateNodeHeader(this);
+    public void UpdateNodeView(Func<Asn1TreeNode, Boolean>? filter) {
+        updateNodeHeader(this, filter);
     }
 
-    void updateNodeHeader(Asn1TreeNode node) {
-        node.Value.UpdateNodeHeader(_dataSource.RawData, _dataSource.NodeViewOptions);
+    void updateNodeHeader(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {
+        if (filter is null || filter(node)) {
+            node.Value.UpdateNodeHeader(_dataSource.RawData, _dataSource.NodeViewOptions);
+        }
         foreach (Asn1TreeNode child in node.Children) {
-            updateNodeHeader(child);
+            updateNodeHeader(child, filter);
         }
     }
     void notifySizeChanged(Asn1TreeNode source, Int32 difference) {

--- a/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
@@ -115,18 +115,24 @@ public class Asn1TreeNode : INotifyPropertyChanged {
     }
 
     public void UpdateNodeView(Func<Asn1TreeNode, Boolean>? filter) {
-        updateNodeHeader(this, filter);
+        updateNode(this, filter, Value.UpdateNode);
     }
     public Task UpdateNodeViewAsync(Func<Asn1TreeNode, Boolean>? filter) {
         return Task.Run(() => UpdateNodeView(filter));
     }
+    public void UpdateNodeHeader(Func<Asn1TreeNode, Boolean>? filter) {
+        updateNode(this, filter, Value.UpdateNodeHeader);
+    }
+    public Task UpdateNodeHeaderAsync(Func<Asn1TreeNode, Boolean>? filter) {
+        return Task.Run(() => UpdateNodeView(filter));
+    }
 
-    void updateNodeHeader(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {
+    void updateNode(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter, Action<IReadOnlyList<Byte>, NodeViewOptions> action) {
         if (filter is null || filter(node)) {
-            node.Value.UpdateNode(_dataSource.RawData, _dataSource.NodeViewOptions);
+            action.Invoke(_dataSource.RawData, _dataSource.NodeViewOptions);
         }
         foreach (Asn1TreeNode child in node.Children) {
-            updateNodeHeader(child, filter);
+            updateNode(child, filter, action);
         }
     }
     void notifySizeChanged(Asn1TreeNode source, Int32 difference) {

--- a/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Parser;
 
@@ -115,6 +116,9 @@ public class Asn1TreeNode : INotifyPropertyChanged {
 
     public void UpdateNodeView(Func<Asn1TreeNode, Boolean>? filter) {
         updateNodeHeader(this, filter);
+    }
+    public Task UpdateNodeViewAsync(Func<Asn1TreeNode, Boolean>? filter) {
+        return Task.Run(() => UpdateNodeView(filter));
     }
 
     void updateNodeHeader(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {

--- a/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
@@ -123,7 +123,7 @@ public class Asn1TreeNode : INotifyPropertyChanged {
 
     void updateNodeHeader(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {
         if (filter is null || filter(node)) {
-            node.Value.UpdateNodeHeader(_dataSource.RawData, _dataSource.NodeViewOptions);
+            node.Value.UpdateNode(_dataSource.RawData, _dataSource.NodeViewOptions);
         }
         foreach (Asn1TreeNode child in node.Children) {
             updateNodeHeader(child, filter);

--- a/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
+++ b/Asn1Editor/API/ModelObjects/Asn1TreeNode.cs
@@ -115,24 +115,32 @@ public class Asn1TreeNode : INotifyPropertyChanged {
     }
 
     public void UpdateNodeView(Func<Asn1TreeNode, Boolean>? filter) {
-        updateNode(this, filter, Value.UpdateNode);
+        updateNodeView(this, filter);
     }
     public Task UpdateNodeViewAsync(Func<Asn1TreeNode, Boolean>? filter) {
         return Task.Run(() => UpdateNodeView(filter));
     }
     public void UpdateNodeHeader(Func<Asn1TreeNode, Boolean>? filter) {
-        updateNode(this, filter, Value.UpdateNodeHeader);
+        updateNodeHeader(this, filter);
     }
     public Task UpdateNodeHeaderAsync(Func<Asn1TreeNode, Boolean>? filter) {
         return Task.Run(() => UpdateNodeView(filter));
     }
 
-    void updateNode(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter, Action<IReadOnlyList<Byte>, NodeViewOptions> action) {
+    void updateNodeView(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {
         if (filter is null || filter(node)) {
-            action.Invoke(_dataSource.RawData, _dataSource.NodeViewOptions);
+            node.Value.UpdateNode(_dataSource.RawData, _dataSource.NodeViewOptions);
         }
         foreach (Asn1TreeNode child in node.Children) {
-            updateNode(child, filter, action);
+            updateNodeView(child, filter);
+        }
+    }
+    void updateNodeHeader(Asn1TreeNode node, Func<Asn1TreeNode, Boolean>? filter) {
+        if (filter is null || filter(node)) {
+            node.Value.UpdateNodeHeader(_dataSource.RawData, _dataSource.NodeViewOptions);
+        }
+        foreach (Asn1TreeNode child in node.Children) {
+            updateNodeView(child, filter);
         }
     }
     void notifySizeChanged(Asn1TreeNode source, Int32 difference) {

--- a/Asn1Editor/API/ModelObjects/DataSource.cs
+++ b/Asn1Editor/API/ModelObjects/DataSource.cs
@@ -17,7 +17,7 @@ class DataSource(NodeViewOptions viewOptions) : ViewModelBase, IDataSource {
     Asn1TreeNode selectedNode;
 
     protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e) {
-        if (_rawData.IsNotifying && CollectionChanged != null) {
+        if (_rawData.IsNotifying && CollectionChanged is not null) {
             try {
                 CollectionChanged(this, e);
             } catch (NotSupportedException) {
@@ -39,7 +39,7 @@ class DataSource(NodeViewOptions viewOptions) : ViewModelBase, IDataSource {
 
     Asn1Lite createNewNode(Byte[] nodeRawData) {
         var node = new Asn1Lite(new Asn1Reader(nodeRawData));
-        if (SelectedNode != null) {
+        if (SelectedNode is not null) {
             node.Offset = SelectedNode.Value.Offset + SelectedNode.Value.TagLength;
             node.Depth += SelectedNode.Value.Depth;
         }
@@ -68,7 +68,7 @@ class DataSource(NodeViewOptions viewOptions) : ViewModelBase, IDataSource {
         return SelectedNode = node;
     }
     public async Task InsertNode(Byte[] nodeRawData, NodeAddOption option) {
-        if (SelectedNode == null) {
+        if (SelectedNode is null) {
             throw new ArgumentNullException(nameof(SelectedNode));
         }
         var childNode = await AsnTreeBuilder.BuildTreeAsync(nodeRawData, this);
@@ -114,9 +114,7 @@ class DataSource(NodeViewOptions viewOptions) : ViewModelBase, IDataSource {
     }
     public void FinishBinaryUpdate() {
         OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-        if (Tree.Count > 0) {
-            Tree[0].UpdateNodeView();
-        }
+        RequireTreeRefresh?.Invoke(this, EventArgs.Empty);
     }
     public IReadOnlyList<Byte> RawData => _rawData;
 
@@ -134,4 +132,5 @@ class DataSource(NodeViewOptions viewOptions) : ViewModelBase, IDataSource {
     }
 
     public event NotifyCollectionChangedEventHandler CollectionChanged;
+    public event EventHandler RequireTreeRefresh;
 }

--- a/Asn1Editor/API/ModelObjects/NodeViewOptions.cs
+++ b/Asn1Editor/API/ModelObjects/NodeViewOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml.Serialization;
 using SysadminsLV.Asn1Editor.API.ViewModel;
+using SysadminsLV.Asn1Parser;
 
 namespace SysadminsLV.Asn1Editor.API.ModelObjects; 
 
@@ -100,7 +101,7 @@ public class NodeViewOptions : ViewModelBase {
             }
             intAsInt = value;
             OnPropertyChanged();
-            triggerRequireTreeRefresh();
+            triggerRequireTreeRefresh(x => x.Value.Tag == (Byte)Asn1Type.INTEGER);
         }
     }
     [XmlElement("showHexViewer")]
@@ -171,9 +172,12 @@ public class NodeViewOptions : ViewModelBase {
         }
     }
 
-    void triggerRequireTreeRefresh() {
-        RequireTreeRefresh?.Invoke(this, EventArgs.Empty);
+    void triggerRequireTreeRefresh(Func<Asn1TreeNode, Boolean>? filter = null) {
+        RequireTreeRefresh?.Invoke(this, new RequireTreeRefreshEventArgs(filter));
     }
 
-    public event EventHandler RequireTreeRefresh;
+    public event EventHandler<RequireTreeRefreshEventArgs> RequireTreeRefresh;
+}
+public class RequireTreeRefreshEventArgs(Func<Asn1TreeNode, Boolean>? filter = null) : EventArgs {
+    public Func<Asn1TreeNode, Boolean>? Filter { get; } = filter;
 }

--- a/Asn1Editor/API/OidResolver.cs
+++ b/Asn1Editor/API/OidResolver.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using SysadminsLV.Asn1Editor.API.Abstractions;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
 
@@ -11,7 +12,7 @@ namespace SysadminsLV.Asn1Editor.API;
 
 interface IOidDbManager {
     void ReloadLookup();
-    Boolean SaveUserLookup();
+    Task<Boolean> SaveUserLookup();
 }
 class OidDbManager(IUIMessenger uiMessenger) : IOidDbManager {
 
@@ -22,12 +23,12 @@ class OidDbManager(IUIMessenger uiMessenger) : IOidDbManager {
         OidResolver.Reset();
         readOids();
     }
-    public Boolean SaveUserLookup() {
+    public async Task<Boolean> SaveUserLookup() {
         try {
             String path = Path.Combine(OidLookupLocations[1], oidFileName);
             using var stream = new StreamWriter(path);
             foreach (OidDto oid in OidResolver.GetOidLookup().Where(x => x.UserDefined)) {
-                stream.WriteLine(oid.Value + "," + oid.FriendlyName);
+                await stream.WriteLineAsync(oid.Value + "," + oid.FriendlyName);
             }
         } catch (Exception ex) {
             uiMessenger.ShowError($"User OID lookup save failed:\n{ex.Message}");

--- a/Asn1Editor/API/Utils/ASN/AsnTreeBuilder.cs
+++ b/Asn1Editor/API/Utils/ASN/AsnTreeBuilder.cs
@@ -35,7 +35,7 @@ public static class AsnTreeBuilder {
     /// <returns>Root node with decoded children nodes.</returns>
     /// <remarks>This method is an asynchronous version of <see cref="BuildTree(Byte[], IDataSource)"/></remarks>
     public static Task<Asn1TreeNode> BuildTreeAsync(Byte[] rawData, IDataSource dataSource) {
-        return Task.Factory.StartNew(() => BuildTree(rawData, dataSource));
+        return Task.Run(() => BuildTree(rawData, dataSource));
     }
     /// <summary>
     /// Gets a new ASN.1 tree from existing data source.

--- a/Asn1Editor/API/Utils/FileUtility.cs
+++ b/Asn1Editor/API/Utils/FileUtility.cs
@@ -28,7 +28,7 @@ static class FileUtility {
         return true;
     }
     public static Task<IEnumerable<Byte>> FileToBinaryAsync(String path) {
-        return Task.Factory.StartNew(() => FileToBinary(path));
+        return Task.Run(() => FileToBinary(path));
     }
     public static IEnumerable<Byte> FileToBinary(String path) {
         FileInfo fileInfo = new FileInfo(path);

--- a/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
+++ b/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
@@ -92,7 +92,7 @@ public class Asn1DocumentVM : AsyncViewModel {
         }
         ProgressText = "Refreshing view...";
         IsBusy = true;
-        await Task.Factory.StartNew(() => Tree[0].UpdateNodeView());
+        await Task.Factory.StartNew(() => Tree[0].UpdateNodeView(filter));
         IsBusy = false;
     }
     public async Task Decode(IEnumerable<Byte> bytes, Boolean doNotSetModifiedFlag) {

--- a/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
+++ b/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
@@ -92,7 +92,7 @@ public class Asn1DocumentVM : AsyncViewModel {
         }
         ProgressText = "Refreshing view...";
         IsBusy = true;
-        await Task.Factory.StartNew(() => Tree[0].UpdateNodeView(filter));
+        await Tree[0].UpdateNodeViewAsync(filter);
         IsBusy = false;
     }
     public async Task Decode(IEnumerable<Byte> bytes, Boolean doNotSetModifiedFlag) {

--- a/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
+++ b/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
@@ -20,7 +20,7 @@ public class Asn1DocumentVM : AsyncViewModel {
         TreeCommands = treeCommands;
     }
     async void onTreeRefreshRequired(Object sender, EventArgs e) {
-        await RefreshTree();
+        await RefreshTreeView();
     }
     void onDataSourceCollectionChanged(Object sender, NotifyCollectionChangedEventArgs args) {
         if (!suppressModified) {
@@ -86,13 +86,20 @@ public class Asn1DocumentVM : AsyncViewModel {
         }
     }
 
-    public async Task RefreshTree(Func<Asn1TreeNode, Boolean>? filter = null) {
+    public Task RefreshTreeView(Func<Asn1TreeNode, Boolean>? filter = null) {
+        return refreshTree(Tree[0].UpdateNodeViewAsync, filter);
+    }
+    public Task RefreshTreeHeaders(Func<Asn1TreeNode, Boolean>? filter = null) {
+        return refreshTree(Tree[0].UpdateNodeHeaderAsync, filter);
+    }
+
+    async Task refreshTree(Func<Func<Asn1TreeNode, Boolean>?, Task> action, Func<Asn1TreeNode, Boolean>? filter = null) {
         if (Tree.Count == 0) {
             return;
         }
         ProgressText = "Refreshing view...";
         IsBusy = true;
-        await Tree[0].UpdateNodeViewAsync(filter);
+        await action.Invoke(filter);
         IsBusy = false;
     }
     public async Task Decode(IEnumerable<Byte> bytes, Boolean doNotSetModifiedFlag) {

--- a/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -43,8 +43,8 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         addTabToList(new Asn1DocumentVM(NodeViewOptions, TreeCommands));
     }
 
-    void onNodeViewOptionsChanged(Object sender, EventArgs args) {
-        RefreshTabs();
+    async void onNodeViewOptionsChanged(Object sender, EventArgs args) {
+        await RefreshTabs();
     }
 
     public ICommand NewCommand { get; }
@@ -306,11 +306,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         return tab.Decode(rawBytes, false);
     }
 
-    public void RefreshTabs() {
-        foreach (Asn1DocumentVM tab in Tabs) {
-            if (tab.Tree.Any()) {
-                tab.Tree[0].UpdateNodeView();
-            }
-        }
+    public Task RefreshTabs() {
+        return Task.WhenAll(Tabs.Select(x => x.RefreshTree()));
     }
 }

--- a/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -43,8 +43,8 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         addTabToList(new Asn1DocumentVM(NodeViewOptions, TreeCommands));
     }
 
-    async void onNodeViewOptionsChanged(Object sender, EventArgs args) {
-        await RefreshTabs();
+    async void onNodeViewOptionsChanged(Object sender, RequireTreeRefreshEventArgs args) {
+        await RefreshTabs(args.Filter);
     }
 
     public ICommand NewCommand { get; }

--- a/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -306,7 +306,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         return tab.Decode(rawBytes, false);
     }
 
-    public Task RefreshTabs() {
-        return Task.WhenAll(Tabs.Select(x => x.RefreshTree()));
+    public Task RefreshTabs(Func<Asn1TreeNode, Boolean>? filter = null) {
+        return Task.WhenAll(Tabs.Select(x => x.RefreshTree(filter)));
     }
 }

--- a/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -307,6 +307,6 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
     }
 
     public Task RefreshTabs(Func<Asn1TreeNode, Boolean>? filter = null) {
-        return Task.WhenAll(Tabs.Select(x => x.RefreshTree(filter)));
+        return Task.WhenAll(Tabs.Select(x => x.RefreshTreeView(filter)));
     }
 }

--- a/Asn1Editor/API/ViewModel/OidEditorVM.cs
+++ b/Asn1Editor/API/ViewModel/OidEditorVM.cs
@@ -8,6 +8,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using SysadminsLV.Asn1Editor.API.Abstractions;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
+using SysadminsLV.Asn1Parser;
 using SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
@@ -136,7 +137,7 @@ class OidEditorVM : ViewModelBase, IOidEditorVM {
             reset(null);
         }
         OidView.Refresh();
-        await _tabs.RefreshTabs();
+        await _tabs.RefreshTabs(x => x.Value.Tag == (Byte)Asn1Type.OBJECT_IDENTIFIER);
     }
     Boolean canSave(Object o) {
         return !String.IsNullOrWhiteSpace(OidValue) && !String.IsNullOrWhiteSpace(FriendlyName) && _regex.IsMatch(OidValue);
@@ -157,7 +158,7 @@ class OidEditorVM : ViewModelBase, IOidEditorVM {
             FriendlyName = null;
             OidResolver.Add(backupOid.Value, backupOid.FriendlyName, backupOid.UserDefined);
         } else {
-            await _tabs.RefreshTabs();
+            await _tabs.RefreshTabs(x => x.Value.Tag == (Byte)Asn1Type.OBJECT_IDENTIFIER);
         }
     }
     Boolean canRemoveOid(Object o) {

--- a/Asn1Editor/Views/Windows/MainWindow.xaml
+++ b/Asn1Editor/Views/Windows/MainWindow.xaml
@@ -507,8 +507,8 @@
                                 </c:AsnTreeView.ContextMenu>
                             </c:AsnTreeView>
                             <c:BusyIndicator IsShown="{Binding IsBusy}"
-                                                    HeaderText="Please wait while decoding the file..."
-                                                    Text="This may take a while"/>
+                                             HeaderText="{Binding ProgressText}"
+                                             Text="This may take a while"/>
                         </Grid>
                     </DockPanel>
                 </DataTemplate>


### PR DESCRIPTION
This PR addresses #86 in a way:

- potentially long-running tasks associated with tree refresh are asynchronous
- new asynchronous tasks reflected by a progress overlay
- optimized tree refresh performance. If OID mapping is changed, then only OID nodes are refreshed, the rest nodes remain unchanged. If ASN.1 INTEGER view mode is changed, only INTEGER nodes are updated, the rest nodes remain unchanged.