### PR TITLE
Added virtualization to TreeViewItem.

### DIFF
--- a/Asn1Editor.Wpf.Controls/Themes/AsnTreeView.xaml
+++ b/Asn1Editor.Wpf.Controls/Themes/AsnTreeView.xaml
@@ -5,8 +5,18 @@
         <ResourceDictionary Source="Shared.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
+    <Style TargetType="TreeViewItem" BasedOn="{StaticResource {x:Type TreeViewItem}}">
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
     <Style TargetType="controls:AsnTreeView" BasedOn="{StaticResource {x:Type TreeView}}">
         <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True"/>
+        <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="BorderBrush" Value="{StaticResource PanelBorderBrush}"/>
         <Setter Property="FontFamily" Value="Consolas"/>


### PR DESCRIPTION
Added virtualization to TreeViewItem. By default, TreeView virtualizes only top-level nodes, not child nodes.