### PR TITLE
fixed #130

### DIFF
--- a/src/SysadminsLV.Asn1Editor.Core/ASN/AsnDecoder.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/ASN/AsnDecoder.cs
@@ -157,7 +157,7 @@ public static class AsnDecoder {
             case Asn1Type.BIT_STRING:
                 return new Asn1BitString(HexUtility.HexToBinary(value), unusedBits).GetRawData();
             case Asn1Type.OCTET_STRING:
-                return new Asn1OctetString(HexUtility.HexToBinary(value), false).GetRawData();
+                return new Asn1OctetString(HexUtility.HexToBinary(value), true).GetRawData();
             case Asn1Type.NULL:
                 return new Asn1Null().GetRawData();
             case Asn1Type.OBJECT_IDENTIFIER:


### PR DESCRIPTION
fixed #130

#### PR Classification
Bug fix to correct the handling of OCTET_STRING encoding in the AsnDecoder class.

#### PR Summary
This pull request updates the AsnDecoder to properly configure the Asn1OctetString constructor when encoding OCTET_STRING values.
- AsnDecoder.cs: Changes the second argument in the Asn1OctetString constructor from false to true to adjust OCTET_STRING encoding behavior.
