### PR TITLE
Changed log file name format for easier sorting

### DIFF
--- a/src/Asn1Editor/API/Utils/Logger.cs
+++ b/src/Asn1Editor/API/Utils/Logger.cs
@@ -12,7 +12,7 @@ class Logger : IDisposable {
 
     public Logger(String appDataDirectory) {
         _logDirectory = Directory.CreateDirectory(Path.Combine(appDataDirectory, "Logs")).FullName;
-        String dt = "Log-" + DateTime.Now.ToString("ddMMyyyyHHmmss");
+        String dt = "Log-" + DateTime.Now.ToString("yyyy-MM-dd-HHmmss");
         sessionStream = new StreamWriter(Path.Combine(_logDirectory, $"{dt}-{Process.GetCurrentProcess().Id}.log")) { AutoFlush = true };
         Task.Run(flushOldLogs);
     }
@@ -32,7 +32,7 @@ class Logger : IDisposable {
         sessionStream.WriteLine(s);
     }
     public void Write(Exception e) {
-        String dt = DateTime.Now.ToString("dd-MM-yyyy HH:mm:ss");
+        String dt = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         sessionStream.WriteLine($"[{dt}]" + " An exception has been thrown:");
         Exception? ex = e;
         do {


### PR DESCRIPTION
Changed log file name format for easier sorting

#### PR Classification
Code cleanup to improve log file naming and timestamp consistency.

#### PR Summary
This pull request updates the date and time formats used in log file names and exception log entries to follow the ISO 8601 standard for better readability and sorting.
- Logger.cs: Changed log file and exception entry date/time formats to "yyyy-MM-dd" and "HHmmss"/"HH:mm:ss" (ISO 8601 style).
