### PR TITLE
Massive MainWindowVM refactoring with better SRP separation

### DIFF
--- a/src/Asn1Editor/API/Interfaces/IHasAsnDocumentTabs.cs
+++ b/src/Asn1Editor/API/Interfaces/IHasAsnDocumentTabs.cs
@@ -6,7 +6,24 @@ using SysadminsLV.Asn1Editor.Core.Tree;
 namespace SysadminsLV.Asn1Editor.API.Interfaces;
 
 public interface IHasAsnDocumentTabs {
+    /// <summary>
+    /// Gets the currently selected tab in the ASN.1 document editor.
+    /// </summary>
+    /// <value>
+    /// An instance of <see cref="AsnDocumentHostVM"/> representing the selected tab, or <c>null</c> if no tab is selected.
+    /// </value>
     AsnDocumentHostVM? SelectedTab { get; }
 
+    /// <summary>
+    /// Refreshes the tabs in the ASN.1 document interface, applying an optional filter to determine
+    /// which nodes should be updated.
+    /// </summary>
+    /// <param name="filter">
+    /// A function that defines the filtering logic for nodes. If provided, only nodes that satisfy
+    /// the filter condition will be refreshed. If <see langword="null"/>, all nodes will be refreshed.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation of refreshing the tabs.
+    /// </returns>
     Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null);
 }

--- a/src/Asn1Editor/API/Interfaces/IHasAsnDocumentTabs.cs
+++ b/src/Asn1Editor/API/Interfaces/IHasAsnDocumentTabs.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
-using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.ViewModel;
 using SysadminsLV.Asn1Editor.Core.Tree;
 
 namespace SysadminsLV.Asn1Editor.API.Interfaces;
 
 public interface IHasAsnDocumentTabs {
-    UserSettings UserSettings { get; }
     AsnDocumentHostVM? SelectedTab { get; }
 
     Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null);

--- a/src/Asn1Editor/API/Interfaces/IMainWindowVM.cs
+++ b/src/Asn1Editor/API/Interfaces/IMainWindowVM.cs
@@ -9,17 +9,7 @@ public interface IMainWindowVM {
     AsnDocumentHostVM? SelectedTab { get; }
 
     /// <summary>
-    /// Raises UI prompt if user wants to save contents of unsaved file.
-    /// </summary>
-    /// <param name="tab">Document to save.</param>
-    /// <returns>
-    ///     <para><strong>True</strong> if user opted to save and save action succeeded or user opted to not save file.</para>
-    ///     <para><strong>False</strong> if user opted to save file and save action failed or user opted to cancel operation.</para>
-    /// </returns>
-    Boolean RequestFileSave(AsnDocumentHostVM tab);
-    /// <summary>
-    /// Requests all tab closing. Internally, this method calls <see cref="RequestFileSave"/> method to prompt to
-    /// save unsaved data.
+    /// Requests all tab closing. Internally, this method calls a prompt to save unsaved data if necessary.
     /// </summary>
     /// <returns>
     ///     <para><strong>True</strong> if user opted to save unsaved files and save action succeeded or user opted to not save file.</para>

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
@@ -193,7 +193,7 @@ class AsnDocumentFileService {
     /// If a new tab was created but decoding fails the temporary tab is closed.
     /// </summary>
     public async Task CreateTabFromFileAsync(String file) {
-        AsnDocumentHostVM tab = _tabManager.GetAvailableTab(out Boolean isNew);
+        AsnDocumentHostVM tab = _tabManager.GetAvailableTab(_treeCommands, out Boolean isNew);
         Asn1DocumentVM doc = tab.GetPrimaryDocument();
         doc.Path = file;
         try {

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
@@ -16,17 +16,11 @@ class AsnDocumentFileService {
     readonly IUIMessenger _uiMessenger;
     readonly AsnDocumentHostManager _tabManager;
     readonly ITreeCommands _treeCommands;
-    readonly Func<AsnDocumentHostVM, Boolean> _requestFileSave;
 
-    public AsnDocumentFileService(
-        IUIMessenger uiMessenger,
-        AsnDocumentHostManager tabManager,
-        ITreeCommands treeCommands,
-        Func<AsnDocumentHostVM, Boolean> requestFileSave) {
+    public AsnDocumentFileService(IUIMessenger uiMessenger, AsnDocumentHostManager tabManager, ITreeCommands treeCommands) {
         _uiMessenger = uiMessenger;
         _tabManager = tabManager;
         _treeCommands = treeCommands;
-        _requestFileSave = requestFileSave;
     }
 
     #region Open

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
@@ -15,14 +15,17 @@ namespace SysadminsLV.Asn1Editor.API.ViewModel;
 class AsnDocumentFileService {
     readonly IUIMessenger _uiMessenger;
     readonly AsnDocumentHostManager _tabManager;
+    readonly ITreeCommands _treeCommands;
     readonly Func<AsnDocumentHostVM, Boolean> _requestFileSave;
 
     public AsnDocumentFileService(
         IUIMessenger uiMessenger,
         AsnDocumentHostManager tabManager,
+        ITreeCommands treeCommands,
         Func<AsnDocumentHostVM, Boolean> requestFileSave) {
         _uiMessenger = uiMessenger;
         _tabManager = tabManager;
+        _treeCommands = treeCommands;
         _requestFileSave = requestFileSave;
     }
 
@@ -66,7 +69,7 @@ class AsnDocumentFileService {
         var asn = new Asn1Reader(rawBytes);
         try {
             asn.BuildOffsetMap();
-            var tab = _tabManager.GetAvailableTab(out _);
+            AsnDocumentHostVM tab = _tabManager.GetAvailableTab(_treeCommands, out _);
             return tab.GetPrimaryDocument().Decode(rawBytes, false);
         } catch (Exception ex) {
             _uiMessenger.ShowError(ex.Message, "Read Error");

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentFileService.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using SysadminsLV.Asn1Editor.API.Interfaces;
+using SysadminsLV.Asn1Editor.API.Utils;
+using SysadminsLV.Asn1Parser;
+
+namespace SysadminsLV.Asn1Editor.API.ViewModel;
+
+/// <summary>
+/// Handles all file I/O operations for ASN.1 document tabs: opening, saving, reloading and drag-dropping files.
+/// </summary>
+class AsnDocumentFileService {
+    readonly IUIMessenger _uiMessenger;
+    readonly AsnDocumentHostManager _tabManager;
+    readonly Func<AsnDocumentHostVM, Boolean> _requestFileSave;
+
+    public AsnDocumentFileService(
+        IUIMessenger uiMessenger,
+        AsnDocumentHostManager tabManager,
+        Func<AsnDocumentHostVM, Boolean> requestFileSave) {
+        _uiMessenger = uiMessenger;
+        _tabManager = tabManager;
+        _requestFileSave = requestFileSave;
+    }
+
+    #region Open
+
+    /// <summary>
+    /// Prompts the user to choose a file and opens it in a tab.
+    /// </summary>
+    public Task OpenFileAsync() {
+        _uiMessenger.TryGetOpenFileName(out String filePath);
+        if (String.IsNullOrWhiteSpace(filePath)) {
+            return Task.CompletedTask;
+        }
+
+        return CreateTabFromFileAsync(filePath);
+    }
+
+    /// <summary>
+    /// Opens a file from a known path in a tab. Used by drag-drop and external callers.
+    /// </summary>
+    public Task OpenExistingAsync(String filePath) {
+        return CreateTabFromFileAsync(filePath);
+    }
+
+    /// <summary>
+    /// Handles a drag-drop operation: validates the dropped path and opens the file.
+    /// </summary>
+    public Task DropFileAsync(String? filePath) {
+        if (File.Exists(filePath)) {
+            return CreateTabFromFileAsync(filePath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Decodes raw bytes (already validated as DER) and loads them into an available tab.
+    /// Exposed as a delegate to the converter window.
+    /// </summary>
+    public Task OpenRawAsync(Byte[] rawBytes) {
+        var asn = new Asn1Reader(rawBytes);
+        try {
+            asn.BuildOffsetMap();
+            var tab = _tabManager.GetAvailableTab(out _);
+            return tab.GetPrimaryDocument().Decode(rawBytes, false);
+        } catch (Exception ex) {
+            _uiMessenger.ShowError(ex.Message, "Read Error");
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Decodes a Base64-encoded string and loads the result into an available tab.
+    /// </summary>
+    public async Task OpenRawAsync(String base64String) {
+        try {
+            await OpenRawAsync(Convert.FromBase64String(base64String));
+        } catch (Exception ex) {
+            _uiMessenger.ShowError(ex.Message, "Read Error");
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Reloads the primary document of the currently selected tab from disk.
+    /// Prompts the user for confirmation if the document has unsaved changes.
+    /// </summary>
+    public async Task ReloadActiveDocumentAsync() {
+        AsnDocumentHostVM? selectedTab = _tabManager.SelectedTab;
+        if (selectedTab is null) {
+            return;
+        }
+        Asn1DocumentVM doc = selectedTab.GetPrimaryDocument();
+        if (String.IsNullOrEmpty(doc.Path)) {
+            return;
+        }
+        if (doc.IsModified) {
+            Boolean confirmResult = _uiMessenger.YesNo(
+                "Reloading will discard all unsaved changes. Do you want to continue?",
+                "Confirm Reload");
+            if (!confirmResult) {
+                return;
+            }
+        }
+
+        try {
+            doc.Reset();
+            IEnumerable<Byte> bytes = await FileUtility.FileToBinaryAsync(doc.Path);
+            await doc.Decode(bytes, true);
+        } catch (Exception ex) {
+            _uiMessenger.ShowError(ex.Message, "Reload Error");
+        }
+    }
+
+    #region Save/Write
+
+    // 'obj' parameter semantics:
+    //   null  – save current tab using its existing/default path
+    //   "1"   – save current tab with a user-chosen path (Save As)
+    //   "2"   – save all tabs (reserved for future use)
+    /// <summary>
+    /// Entry point for all save commands.
+    /// </summary>
+    public void SaveFile(String? obj) {
+        AsnDocumentHostVM? selectedTab = _tabManager.SelectedTab;
+        if (obj is null) {
+            WriteFile(selectedTab);
+        } else {
+            switch (obj) {
+                case "1": {
+                    if (GetSaveFilePath(out String filePath)) {
+                        WriteFile(selectedTab, filePath);
+                    }
+                    break;
+                }
+                case "2":
+                    // save all tabs — reserved
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the save / print commands should be enabled.
+    /// </summary>
+    public Boolean CanSave(Object obj) {
+        return _tabManager.SelectedTab?.GetPrimaryDocument().AsnDocContext.RawData.Count > 0;
+    }
+
+    /// <summary>
+    /// Writes the primary document of <paramref name="tab"/> to disk.
+    /// If <paramref name="filePath"/> is omitted the document's existing path is used;
+    /// if that is also absent the user is prompted for a save location.
+    /// </summary>
+    /// <returns><see langword="true"/> on success; <see langword="false"/> if the operation was cancelled or failed.</returns>
+    public Boolean WriteFile(AsnDocumentHostVM? tab, String? filePath = null) {
+        if (tab is null) {
+            return false;
+        }
+        Asn1DocumentVM doc = tab.GetPrimaryDocument();
+        filePath ??= doc.Path;
+        if (String.IsNullOrEmpty(filePath) && !GetSaveFilePath(out filePath)) {
+            return false;
+        }
+        try {
+            File.WriteAllBytes(filePath, doc.AsnDocContext.RawData.ToArray());
+            doc.Path = filePath;
+            doc.IsModified = false;
+            return true;
+        } catch (Exception e) {
+            _uiMessenger.ShowError(e.Message, "Save Error");
+        }
+        return false;
+    }
+
+    public Boolean GetSaveFilePath(out String saveFilePath) {
+        return _uiMessenger.TryGetSaveFileName(out saveFilePath);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Reads a file from disk and decodes it into an available tab.
+    /// If a new tab was created but decoding fails the temporary tab is closed.
+    /// </summary>
+    public async Task CreateTabFromFileAsync(String file) {
+        AsnDocumentHostVM tab = _tabManager.GetAvailableTab(out Boolean isNew);
+        Asn1DocumentVM doc = tab.GetPrimaryDocument();
+        doc.Path = file;
+        try {
+            IEnumerable<Byte> bytes = await FileUtility.FileToBinaryAsync(file);
+            await doc.Decode(bytes, true);
+        } catch (Exception ex) {
+            _uiMessenger.ShowError(ex.Message, "Read Error");
+            if (isNew) {
+                _tabManager.RemoveTab(tab);
+            }
+        }
+    }
+}

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.SessionState;
+using SysadminsLV.Asn1Editor.Core.Tree;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
 
@@ -16,13 +19,18 @@ namespace SysadminsLV.Asn1Editor.API.ViewModel;
 /// operations such as creating new tabs, reusing existing tabs, and clearing all tabs.
 /// It implements the <see cref="ISessionTabHost"/> interface to provide session tab management capabilities.
 /// </remarks>
-class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
+class AsnDocumentHostManager : ViewModelBase, ISessionTabHost, IHasAsnDocumentTabs {
     readonly ObservableCollection<AsnDocumentHostVM> _tabs = [];
     readonly UserSettings _userSettings;
 
     public AsnDocumentHostManager(UserSettings userSettings) {
         _userSettings = userSettings;
+        _userSettings.RequireTreeRefresh += OnUserSettingsChanged;
         Tabs = new ReadOnlyObservableCollection<AsnDocumentHostVM>(_tabs);
+    }
+
+    async void OnUserSettingsChanged(Object sender, RequireTreeRefreshEventArgs args) {
+        await RefreshTabs(args.Filter);
     }
 
     /// <summary>
@@ -59,6 +67,9 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
                 OnPropertyChanged();
             }
         }
+    }
+    public Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null) {
+        return Task.WhenAll(Tabs.Select(x => x.GetPrimaryDocument().RefreshTreeView(filter)));
     }
 
     /// <summary>

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using SysadminsLV.Asn1Editor.API.Interfaces;
+using SysadminsLV.Asn1Editor.API.ModelObjects;
+using SysadminsLV.Asn1Editor.API.SessionState;
+
+namespace SysadminsLV.Asn1Editor.API.ViewModel;
+
+/// <summary>
+/// Manages the collection of ASN.1 document host view models within the application.
+/// Provides functionality to add, remove, and manage tabs, as well as access the currently selected tab.
+/// </summary>
+/// <remarks>
+/// This class serves as the primary manager for handling multiple ASN.1 document tabs, enabling
+/// operations such as creating new tabs, reusing existing tabs, and clearing all tabs.
+/// It implements the <see cref="ISessionTabHost"/> interface to provide session tab management capabilities.
+/// </remarks>
+class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
+    readonly ObservableCollection<AsnDocumentHostVM> _tabs = [];
+    readonly UserSettings _userSettings;
+    readonly ITreeCommands _treeCommands;
+
+    public AsnDocumentHostManager(UserSettings userSettings, ITreeCommands treeCommands) {
+        _userSettings = userSettings;
+        _treeCommands = treeCommands;
+        Tabs = new ReadOnlyObservableCollection<AsnDocumentHostVM>(_tabs);
+    }
+
+    /// <summary>
+    /// Gets the collection of ASN.1 document host view models currently managed by this instance.
+    /// </summary>
+    /// <value>
+    /// A read-only collection of <see cref="AsnDocumentHostVM"/> objects representing the tabs
+    /// available in the application.
+    /// </value>
+    /// <remarks>
+    /// This property provides access to the tabs managed by the <see cref="AsnDocumentHostManager"/>.
+    /// The collection is read-only to ensure that modifications to the tab list are performed
+    /// exclusively through the methods provided by the manager, such as <see cref="AddTab"/> and
+    /// <see cref="RemoveTab"/>.
+    /// </remarks>
+    public ReadOnlyObservableCollection<AsnDocumentHostVM> Tabs { get; }
+
+    /// <summary>
+    /// Gets or sets the currently selected tab in the collection of ASN.1 document host view models.
+    /// </summary>
+    /// <value>
+    /// An instance of <see cref="AsnDocumentHostVM"/> representing the currently selected tab,
+    /// or <c>null</c> if no tab is selected.
+    /// </value>
+    /// <remarks>
+    /// Changing the selected tab raises the <see cref="INotifyPropertyChanged.PropertyChanged"/> event
+    /// to notify the UI or other components of the update.
+    /// </remarks>
+    public AsnDocumentHostVM? SelectedTab {
+        get;
+        set {
+            if (!Equals(field, value)) {
+                field = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates and adds a new tab to the collection of ASN.1 document host view models.
+    /// </summary>
+    /// <remarks>
+    /// This method initializes a new instance of the <see cref="AsnDocumentHostVM"/> class using the
+    /// current user settings and tree commands, adds it to the tab collection, and sets it as the selected tab.
+    /// </remarks>
+    /// <returns>
+    /// The newly created <see cref="AsnDocumentHostVM"/> instance representing the new tab.
+    /// </returns>
+    public AsnDocumentHostVM AddNewTab() {
+        var tab = new AsnDocumentHostVM(_userSettings, _treeCommands);
+        AddTab(tab);
+        return tab;
+    }
+
+    /// <summary>
+    /// Adds a new ASN.1 document host view model to the collection of managed tabs.
+    /// </summary>
+    /// <param name="tab">
+    /// The <see cref="AsnDocumentHostVM"/> instance to be added as a new tab.
+    /// </param>
+    /// <remarks>
+    /// This method adds the specified tab to the internal collection of tabs and sets it as the currently selected tab.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if the <paramref name="tab"/> parameter is <c>null</c>.
+    /// </exception>
+    public void AddTab(AsnDocumentHostVM tab) {
+        _tabs.Add(tab);
+        SelectedTab = tab;
+    }
+
+    /// <summary>
+    /// Retrieves an available tab for use, either by reusing an existing tab or creating a new one.
+    /// </summary>
+    /// <param name="isNew">
+    /// When this method returns, contains a value indicating whether a new tab was created. 
+    /// <c>true</c> if a new tab was created; otherwise, <c>false</c>.
+    /// </param>
+    /// <returns>
+    /// An instance of <see cref="AsnDocumentHostVM"/> representing the available tab.
+    /// </returns>
+    /// <remarks>
+    /// This method first checks if the currently selected tab can be reused. If it can, the method returns
+    /// the selected tab. Otherwise, a new tab is created and returned.
+    /// </remarks>
+    public AsnDocumentHostVM GetAvailableTab(out Boolean isNew) {
+        isNew = false;
+        Boolean useExistingTab = SelectedTab is not null && SelectedTab.GetPrimaryDocument().CanReuse;
+        if (useExistingTab && Tabs.Any()) {
+            return SelectedTab!;
+        }
+
+        isNew = true;
+        return AddNewTab();
+    }
+
+    /// <summary>
+    /// Removes the specified ASN.1 document host view model from the collection of managed tabs.
+    /// </summary>
+    /// <param name="tab">
+    /// The <see cref="AsnDocumentHostVM"/> instance representing the tab to be removed.
+    /// </param>
+    /// <remarks>
+    /// This method enables the removal of a specific tab from the collection managed by the
+    /// <see cref="AsnDocumentHostManager"/>. If the tab has a secondary document (represented by
+    /// the <see cref="AsnDocumentHostVM.Right"/> property), its <see cref="Asn1DocumentVM.IsEnabled"/>
+    /// property is set to <c>true</c> before the tab is removed.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if the <paramref name="tab"/> parameter is <c>null</c>.
+    /// </exception>
+    public void RemoveTab(AsnDocumentHostVM tab) {
+        tab.Right?.IsEnabled = true;
+        _tabs.Remove(tab);
+    }
+
+    /// <summary>
+    /// Clears all tabs from the collection of ASN.1 document host view models.
+    /// </summary>
+    /// <remarks>
+    /// This method removes all tabs from the internal collection, effectively resetting the state of the manager.
+    /// It does not perform any additional cleanup or disposal of the tab contents.
+    /// </remarks>
+    public void Clear() {
+        _tabs.Clear();
+    }
+}

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -19,11 +19,9 @@ namespace SysadminsLV.Asn1Editor.API.ViewModel;
 class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
     readonly ObservableCollection<AsnDocumentHostVM> _tabs = [];
     readonly UserSettings _userSettings;
-    readonly ITreeCommands _treeCommands;
 
-    public AsnDocumentHostManager(UserSettings userSettings, ITreeCommands treeCommands) {
+    public AsnDocumentHostManager(UserSettings userSettings) {
         _userSettings = userSettings;
-        _treeCommands = treeCommands;
         Tabs = new ReadOnlyObservableCollection<AsnDocumentHostVM>(_tabs);
     }
 
@@ -73,8 +71,8 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
     /// <returns>
     /// The newly created <see cref="AsnDocumentHostVM"/> instance representing the new tab.
     /// </returns>
-    public AsnDocumentHostVM AddNewTab() {
-        var tab = new AsnDocumentHostVM(_userSettings, _treeCommands);
+    public AsnDocumentHostVM AddNewTab(ITreeCommands treeCommands) {
+        var tab = new AsnDocumentHostVM(_userSettings, treeCommands);
         AddTab(tab);
         return tab;
     }
@@ -99,6 +97,7 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
     /// <summary>
     /// Retrieves an available tab for use, either by reusing an existing tab or creating a new one.
     /// </summary>
+    /// <param name="treeCommands">The tree commands to be used for the tab.</param>
     /// <param name="isNew">
     /// When this method returns, contains a value indicating whether a new tab was created. 
     /// <c>true</c> if a new tab was created; otherwise, <c>false</c>.
@@ -110,7 +109,7 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
     /// This method first checks if the currently selected tab can be reused. If it can, the method returns
     /// the selected tab. Otherwise, a new tab is created and returned.
     /// </remarks>
-    public AsnDocumentHostVM GetAvailableTab(out Boolean isNew) {
+    public AsnDocumentHostVM GetAvailableTab(ITreeCommands treeCommands, out Boolean isNew) {
         isNew = false;
         Boolean useExistingTab = SelectedTab is not null && SelectedTab.GetPrimaryDocument().CanReuse;
         if (useExistingTab && Tabs.Count > 0) {
@@ -118,7 +117,7 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
         }
 
         isNew = true;
-        return AddNewTab();
+        return AddNewTab(treeCommands);
     }
 
     /// <summary>

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -152,6 +152,68 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost, IHasAsnDocumentTa
     }
 
     /// <summary>
+    /// Closes the specified tab and optionally prompts the user to save changes if the tab contains unsaved modifications.
+    /// </summary>
+    /// <param name="tab">The tab to be closed.</param>
+    /// <param name="requestFileSave">
+    /// A function that prompts the user to save changes for the specified tab. 
+    /// Returns <see langword="true"/> if the user chooses to save or discard changes, allowing the tab to be closed; 
+    /// otherwise, <see langword="false"/> to cancel the close operation.
+    /// </param>
+    /// <remarks>
+    /// If the tab's primary document is not modified, it is closed immediately without invoking the <paramref name="requestFileSave"/> function.
+    /// If the document is modified, the <paramref name="requestFileSave"/> function is invoked to determine whether to proceed with closing the tab.
+    /// </remarks>
+    public void CloseTab(AsnDocumentHostVM? tab, Func<AsnDocumentHostVM, Boolean> requestFileSave) {
+        tab ??= SelectedTab;
+        if (tab is null) {
+            return;
+        }
+
+        Asn1DocumentVM doc = tab.GetPrimaryDocument();
+        if (!doc.IsModified) {
+            RemoveTab(tab);
+            return;
+        }
+        if (requestFileSave(tab)) {
+            RemoveTab(tab);
+        }
+    }
+    /// <summary>
+    /// Closes all tabs except for the optionally specified preserved tab, ensuring that any unsaved changes
+    /// are handled based on the provided save request function.
+    /// </summary>
+    /// <param name="requestFileSave">
+    /// A delegate that is invoked for each modified tab to determine whether the tab's changes should be saved.
+    /// Returns <c>true</c> if the changes are successfully saved or discarded; otherwise, <c>false</c>.
+    /// </param>
+    /// <param name="preservedTab">
+    /// The tab to preserve during the operation. If <c>null</c>, all tabs are considered for closure.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if all tabs (except the preserved tab) are successfully closed; otherwise, <c>false</c>
+    /// if the operation is interrupted due to unsaved changes.
+    /// </returns>
+    public Boolean CloseTabsWithPreservation(Func<AsnDocumentHostVM, Boolean> requestFileSave, AsnDocumentHostVM? preservedTab = null) {
+        foreach (AsnDocumentHostVM tab in Tabs.ToList()) {
+            if (preservedTab is not null && Equals(tab, preservedTab)) {
+                continue;
+            }
+            Asn1DocumentVM doc = tab.GetPrimaryDocument();
+            if (!doc.IsModified) {
+                RemoveTab(tab);
+                continue;
+            }
+            SelectedTab = tab;
+            if (!requestFileSave(tab)) {
+                return false;
+            }
+            RemoveTab(tab);
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Clears all tabs from the collection of ASN.1 document host view models.
     /// </summary>
     /// <remarks>

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -68,6 +68,7 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost, IHasAsnDocumentTa
             }
         }
     }
+    /// <inheritdoc />
     public Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null) {
         return Task.WhenAll(Tabs.Select(x => x.GetPrimaryDocument().RefreshTreeView(filter)));
     }

--- a/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnDocumentHostManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using SysadminsLV.Asn1Editor.API.Interfaces;
 using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.SessionState;
@@ -114,7 +113,7 @@ class AsnDocumentHostManager : ViewModelBase, ISessionTabHost {
     public AsnDocumentHostVM GetAvailableTab(out Boolean isNew) {
         isNew = false;
         Boolean useExistingTab = SelectedTab is not null && SelectedTab.GetPrimaryDocument().CanReuse;
-        if (useExistingTab && Tabs.Any()) {
+        if (useExistingTab && Tabs.Count > 0) {
             return SelectedTab!;
         }
 

--- a/src/Asn1Editor/API/ViewModel/AsnValueEditorVM.cs
+++ b/src/Asn1Editor/API/ViewModel/AsnValueEditorVM.cs
@@ -16,10 +16,10 @@ class AsnValueEditorVM : ViewModelBase, IAsnValueEditorVM {
     readonly IUIMessenger _uiMessenger;
     readonly IAsn1DocumentContext _data;
 
-    public AsnValueEditorVM(IHasAsnDocumentTabs appTabs, IUIMessenger uiMessenger) {
+    public AsnValueEditorVM(IHasAsnDocumentTabs appTabs, IUIMessenger uiMessenger, UserSettings userSettings) {
         _data = appTabs.SelectedTab!.GetPrimaryDocument().AsnDocContext;
         _uiMessenger = uiMessenger;
-        UserSettings = appTabs.UserSettings;
+        UserSettings = userSettings;
         OkCommand = new RelayCommand(submitValues, canSubmit);
         CloseCommand = new RelayCommand(close);
         TagDetails = String.Empty;

--- a/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -29,12 +29,12 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         UserSettings = userSettings;
         UserSettings.RequireTreeRefresh += OnUserSettingsChanged;
         TreeCommands = new TreeViewCommands(windowFactory, this);
-        DocumentHostManager = new AsnDocumentHostManager(userSettings, TreeCommands);
+        DocumentHostManager = new AsnDocumentHostManager(userSettings);
         _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, requestFileSave);
         GlobalData = new GlobalData();
         AppCommands = appCommands;
         
-        NewCommand = new RelayCommand(_ => DocumentHostManager.AddNewTab());
+        NewCommand = new RelayCommand(_ => DocumentHostManager.AddNewTab(TreeCommands));
         CloseTabCommand = new RelayCommand(closeTab, canCloseTab);
         CloseAllTabsCommand = new RelayCommand(closeAllTabs);
         CloseAllButThisTabCommand = new RelayCommand(closeAllButThisTab, canCloseAllButThisTab);

--- a/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using SysadminsLV.Asn1Editor.API.Interfaces;
@@ -12,16 +10,15 @@ using SysadminsLV.Asn1Editor.API.SessionState;
 using SysadminsLV.Asn1Editor.API.Utils;
 using SysadminsLV.Asn1Editor.API.Utils.WPF;
 using SysadminsLV.Asn1Editor.Core.Tree;
-using SysadminsLV.Asn1Parser;
 using SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
 
-class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISessionTabHost {
+class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
     readonly IWindowFactory _windowFactory;
     readonly IUIMessenger _uiMessenger;
+    readonly AsnDocumentFileService _documentFileService;
     readonly SessionDocumentSource _sessionDocumentSource;
-    readonly ObservableCollection<AsnDocumentHostVM> _tabs = [];
 
     public MainWindowVM(
         IWindowFactory windowFactory,
@@ -29,23 +26,25 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
         UserSettings userSettings) {
         _windowFactory = windowFactory;
         _uiMessenger = windowFactory.GetUIMessenger();
-        Tabs = new ReadOnlyObservableCollection<AsnDocumentHostVM>(_tabs);
-        GlobalData = new GlobalData();
-        AppCommands = appCommands;
-        TreeCommands = new TreeViewCommands(windowFactory, this);
         UserSettings = userSettings;
         UserSettings.RequireTreeRefresh += OnUserSettingsChanged;
-        NewCommand = new RelayCommand(newTab);
+        TreeCommands = new TreeViewCommands(windowFactory, this);
+        DocumentHostManager = new AsnDocumentHostManager(userSettings, TreeCommands);
+        _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, requestFileSave);
+        GlobalData = new GlobalData();
+        AppCommands = appCommands;
+        
+        NewCommand = new RelayCommand(_ => DocumentHostManager.AddNewTab());
         CloseTabCommand = new RelayCommand(closeTab, canCloseTab);
         CloseAllTabsCommand = new RelayCommand(closeAllTabs);
         CloseAllButThisTabCommand = new RelayCommand(closeAllButThisTab, canCloseAllButThisTab);
-        OpenCommand = new AsyncCommand(openFileAsync);
-        SaveCommand = new RelayCommand(saveFile, canPrintSave);
-        ReloadDocumentCommand = new AsyncCommand(reloadDocumentAsync);
-        DropFileCommand = new AsyncCommand(dropFileAsync);
+        OpenCommand = new AsyncCommand((_, _) => _documentFileService.OpenFileAsync());
+        SaveCommand = new RelayCommand(o => _documentFileService.SaveFile(o as String), canPrintSave);
+        ReloadDocumentCommand = new AsyncCommand((_, _) => _documentFileService.ReloadActiveDocumentAsync());
+        DropFileCommand = new AsyncCommand((o, _) => _documentFileService.DropFileAsync(o as String));
         appCommands.ShowConverterWindow = new RelayCommand(showConverter);
-        _sessionDocumentSource = new SessionDocumentSource(this, UserSettings);
-        addTabToList(new AsnDocumentHostVM(UserSettings, TreeCommands));
+        _sessionDocumentSource = new SessionDocumentSource(DocumentHostManager, UserSettings);
+        DocumentHostManager.AddTab(new AsnDocumentHostVM(UserSettings, TreeCommands));
     }
 
     async void OnUserSettingsChanged(Object sender, RequireTreeRefreshEventArgs args) {
@@ -68,14 +67,8 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
 
     public GlobalData GlobalData { get; }
     public UserSettings UserSettings { get; }
-    public ReadOnlyObservableCollection<AsnDocumentHostVM> Tabs { get; }
-    public AsnDocumentHostVM? SelectedTab {
-        get;
-        set {
-            field = value;
-            OnPropertyChanged();
-        }
-    }
+    public AsnDocumentHostManager DocumentHostManager { get; }
+    public AsnDocumentHostVM? SelectedTab => DocumentHostManager.SelectedTab;
 
     /// <summary>
     /// Shows Binary Converter dialog and renders converted ASN data if requested.
@@ -83,172 +76,28 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
     /// <param name="o"></param>
     void showConverter(Object o) {
         if (SelectedTab is null) {
-            _windowFactory.ShowConverterWindow([], openRawAsync);
+            _windowFactory.ShowConverterWindow([], _documentFileService.OpenRawAsync);
         } else {
-            _windowFactory.ShowConverterWindow(SelectedTab.GetPrimaryDocument().AsnDocContext.RawData, openRawAsync);
+            _windowFactory.ShowConverterWindow(SelectedTab.GetPrimaryDocument().AsnDocContext.RawData, _documentFileService.OpenRawAsync);
         }
     }
-    void newTab(Object o) {
-        var tab = new AsnDocumentHostVM(UserSettings, TreeCommands);
-        addTabToList(tab);
-    }
-    /// <summary>
-    /// Adds tab specified by <strong>tab</strong> parameter to <see cref="Tabs"/> list and optionally makes it
-    /// active (sets to <see cref="SelectedTab"/> property).
-    /// </summary>
-    /// <param name="tab">Tab document to add.</param>
-    void addTabToList(AsnDocumentHostVM tab) {
-        _tabs.Add(tab);
-        SelectedTab = tab;
-    }
-    /// <summary>
-    /// Returns a blank tab instance. Either, it is a current value of <see cref="SelectedTab"/> property
-    /// or new tab document instance.
-    /// </summary>
-    /// <param name="isNew">
-    ///     Specifies if method created new tab document instance. This parameter can be used to determine if
-    ///     created tab can be closed should decode fail.
-    /// </param>
-    /// <returns>Blank tab document instance.</returns>
-    AsnDocumentHostVM getAvailableTab(out Boolean isNew) {
-        isNew = false;
-        Boolean useExistingTab = SelectedTab is not null && SelectedTab.GetPrimaryDocument().CanReuse;
-        if (useExistingTab && Tabs.Any()) {
-            return SelectedTab;
-        }
-
-        isNew = true;
-        var tab = new AsnDocumentHostVM(UserSettings, TreeCommands);
-        addTabToList(tab);
-
-        return tab;
-    }
-    /// <summary>
-    /// Creates tab document from file.
-    /// </summary>
-    /// <param name="file">Path to a file that contains valid ASN.1-encoded data.</param>
-    /// <returns>Awaitable task.</returns>
-    /// <remarks>If new tab was created, but file decoding fails, this temporary tab document will be closed.</remarks>
-    async Task createTabFromFile(String file) {
-        var tab = getAvailableTab(out Boolean useExistingTab);
-        var doc = tab.GetPrimaryDocument();
-        doc.Path = file;
-        try {
-            IEnumerable<Byte> bytes = await FileUtility.FileToBinaryAsync(file);
-            await doc.Decode(bytes, true);
-        } catch (Exception ex) {
-            _uiMessenger.ShowError(ex.Message, "Read Error");
-            if (!useExistingTab) {
-                removeTab(tab);
-            }
-        }
-    }
-
-    async Task reloadDocumentAsync(Object o, CancellationToken ct) {
-        if (SelectedTab is null) {
-            return;
-        }
-        var doc = SelectedTab.GetPrimaryDocument();
-        if (String.IsNullOrEmpty(doc.Path)) {
-            return;
-        }
-        // if document is modified, ask user for confirmation to reload and lose unsaved changes.
-        if (doc.IsModified) {
-            Boolean confirmResult = _uiMessenger.YesNo("Reloading will discard all unsaved changes. Do you want to continue?", "Confirm Reload");
-            if (!confirmResult) {
-                return;
-            }
-        }
-
-        try {
-            doc.Reset();
-            IEnumerable<Byte> bytes = await FileUtility.FileToBinaryAsync(doc.Path);
-            await doc.Decode(bytes, true);
-        } catch (Exception ex) {
-            _uiMessenger.ShowError(ex.Message, "Reload Error");
-        }
-    }
-
-    #region Read content to tab
-    Task openFileAsync(Object obj, CancellationToken token = default) {
-        _uiMessenger.TryGetOpenFileName(out String filePath);
-        if (String.IsNullOrWhiteSpace(filePath)) {
-            return Task.CompletedTask;
-        }
-
-        return createTabFromFile(filePath);
-    }
-    #endregion
 
     #region Write tab to file
-    // 'o' parameter can receive:
-    // null - use current tab with default name
-    // 1    - use current tab with custom name
-    // 2    - save all tabs with default name.
-    void saveFile(Object? obj) {
-        if (obj is null) {
-            writeFile(SelectedTab);
-        } else {
-            switch (obj.ToString()) {
-                case "1": {
-                        if (getSaveFilePath(out String filePath)) {
-                            writeFile(SelectedTab, filePath);
-                        }
-
-                        break;
-                    }
-                case "2":
-                    // do something with save all tabs
-                    break;
-            }
-        }
-    }
     Boolean canPrintSave(Object obj) {
         return SelectedTab?.Left.AsnDocContext.RawData.Count > 0;
     }
 
-    // general method to write arbitrary tab to a file.
-    Boolean writeFile(AsnDocumentHostVM tab, String? filePath = null) {
-        Asn1DocumentVM doc = tab.GetPrimaryDocument();
-        // use default path if no custom file path specified
-        filePath ??= doc.Path;
-        // if file path is still null, then it came from "untitled" tab with default file path
-        // so prompt for file to save and abort if cancelled.
-        if (String.IsNullOrEmpty(filePath) && !getSaveFilePath(out filePath)) {
-            return false;
-        }
-        try {
-            File.WriteAllBytes(filePath, doc.AsnDocContext.RawData.ToArray());
-            doc.Path = filePath;
-            doc.IsModified = false;
-
-            return true;
-        } catch (Exception e) {
-            _uiMessenger.ShowError(e.Message, "Save Error");
-        }
-        return false;
-    }
-    Boolean getSaveFilePath(out String saveFilePath) {
-        return _uiMessenger.TryGetSaveFileName(out saveFilePath);
-    }
-
-    public Boolean RequestFileSave(AsnDocumentHostVM tab) {
+    Boolean requestFileSave(AsnDocumentHostVM tab) {
         Boolean? result = _uiMessenger.YesNoCancel("Current file was modified. Save changes?", "Unsaved Data");
         return result switch {
             false => true,
-            true => writeFile(tab),
+            true => _documentFileService.WriteFile(tab),
             _ => false
         };
     }
     #endregion
 
     #region Close Tab(s)
-
-    void removeTab(AsnDocumentHostVM tab) {
-        // unlock Right ASN.1 document if in compare mode
-        tab.Right?.IsEnabled = true;
-        _tabs.Remove(tab);
-    }
 
     void closeTab(Object? o) {
         if (o is AsnDocumentHostVM vm) {
@@ -271,7 +120,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
         }
     }
     Boolean canCloseAllButThisTab(Object? o) {
-        if (Tabs.Count == 0) {
+        if (DocumentHostManager.Tabs.Count == 0) {
             return false;
         }
         if (o is null) {
@@ -284,30 +133,30 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
     void closeTab(AsnDocumentHostVM tab) {
         Asn1DocumentVM doc = tab.GetPrimaryDocument();
         if (!doc.IsModified) {
-            removeTab(tab);
+            DocumentHostManager.RemoveTab(tab);
         }
-        if (doc.IsModified && RequestFileSave(tab)) {
-            removeTab(tab);
+        if (doc.IsModified && requestFileSave(tab)) {
+            DocumentHostManager.RemoveTab(tab);
         }
     }
     Boolean closeTabsWithPreservation(AsnDocumentHostVM? preservedTab = null) {
         // loop over a copy of tabs since we are going to update source collection in a loop
-        var tabs = Tabs.ToList();
+        var tabs = DocumentHostManager.Tabs.ToList();
         foreach (AsnDocumentHostVM tab in tabs) {
             Asn1DocumentVM doc = tab.GetPrimaryDocument();
             if (preservedTab is not null && Equals(tab, preservedTab)) {
                 continue;
             }
             if (!doc.IsModified) {
-                removeTab(tab);
+                DocumentHostManager.RemoveTab(tab);
 
                 continue;
             }
-            SelectedTab = tab;
-            if (!RequestFileSave(tab)) {
+            DocumentHostManager.SelectedTab = tab;
+            if (!requestFileSave(tab)) {
                 return false;
             }
-            removeTab(tab);
+            DocumentHostManager.RemoveTab(tab);
         }
 
         return true;
@@ -323,44 +172,23 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
 
     #endregion
 
-    Task dropFileAsync(Object o, CancellationToken token = default) {
-        if (o is not String filePath || !File.Exists(filePath)) {
-            return Task.CompletedTask;
-        }
-
-        return createTabFromFile(filePath);
-    }
     public Task OpenExistingAsync(String filePath) {
-        return createTabFromFile(filePath);
+        return _documentFileService.OpenExistingAsync(filePath);
     }
     public async Task OpenRawAsync(String base64String) {
         try {
-            await openRawAsync(Convert.FromBase64String(base64String));
+            await _documentFileService.OpenRawAsync(Convert.FromBase64String(base64String));
         } catch (Exception ex) {
             _uiMessenger.ShowError(ex.Message, "Read Error");
-        }
-    }
-    Task openRawAsync(Byte[] rawBytes) {
-        var asn = new Asn1Reader(rawBytes);
-        try {
-            asn.BuildOffsetMap();
-            // at this point, raw data is granted to be valid DER encoding and should not fail.
-            var tab = getAvailableTab(out _);
-
-            return tab.GetPrimaryDocument().Decode(rawBytes, false);
-        } catch (Exception ex) {
-            _uiMessenger.ShowError(ex.Message, "Read Error");
-
-            return Task.CompletedTask;
         }
     }
 
     public Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null) {
-        return Task.WhenAll(Tabs.Select(x => x.GetPrimaryDocument().RefreshTreeView(filter)));
+        return Task.WhenAll(DocumentHostManager.Tabs.Select(x => x.GetPrimaryDocument().RefreshTreeView(filter)));
     }
     public async Task RestoreSessionAsync(SessionRecoveryDto recoveryData) {
         if (recoveryData.Tabs.Count > 0) {
-            _tabs.Clear();
+            DocumentHostManager.Clear();
         }
         var compareDictionary = new Dictionary<String, AsnDocumentHostVM>();
         foreach (SessionTabRecoveryDto recoveryTab in recoveryData.Tabs) {
@@ -391,7 +219,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
 
             doc.ID = recoveryTab.ID;
             doc.Path = recoveryTab.SourcePath;
-            addTabToList(tab);
+            DocumentHostManager.AddTab(tab);
             compareDictionary[recoveryTab.ID] = tab;
         }
 
@@ -403,7 +231,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs, ISession
             }
         }
         if (recoveryData.SelectedTabID is not null) {
-            SelectedTab = Tabs.FirstOrDefault(x => x.GetPrimaryDocument().ID == recoveryData.SelectedTabID);
+            DocumentHostManager.SelectedTab = DocumentHostManager.Tabs.FirstOrDefault(x => x.GetPrimaryDocument().ID == recoveryData.SelectedTabID);
         }
     }
 }

--- a/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -30,7 +30,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         UserSettings.RequireTreeRefresh += OnUserSettingsChanged;
         TreeCommands = new TreeViewCommands(windowFactory, this);
         DocumentHostManager = new AsnDocumentHostManager(userSettings);
-        _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, requestFileSave);
+        _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, TreeCommands, requestFileSave);
         GlobalData = new GlobalData();
         AppCommands = appCommands;
         

--- a/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -9,12 +9,11 @@ using SysadminsLV.Asn1Editor.API.ModelObjects;
 using SysadminsLV.Asn1Editor.API.SessionState;
 using SysadminsLV.Asn1Editor.API.Utils;
 using SysadminsLV.Asn1Editor.API.Utils.WPF;
-using SysadminsLV.Asn1Editor.Core.Tree;
 using SysadminsLV.WPF.OfficeTheme.Toolkit.Commands;
 
 namespace SysadminsLV.Asn1Editor.API.ViewModel;
 
-class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
+class MainWindowVM : ViewModelBase, IMainWindowVM {
     readonly IWindowFactory _windowFactory;
     readonly IUIMessenger _uiMessenger;
     readonly AsnDocumentFileService _documentFileService;
@@ -23,13 +22,14 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
     public MainWindowVM(
         IWindowFactory windowFactory,
         IAppCommands appCommands,
+        AsnDocumentHostManager documentHostManager,
+        ITreeCommands treeCommands,
         UserSettings userSettings) {
         _windowFactory = windowFactory;
         _uiMessenger = windowFactory.GetUIMessenger();
         UserSettings = userSettings;
-        UserSettings.RequireTreeRefresh += OnUserSettingsChanged;
-        TreeCommands = new TreeViewCommands(windowFactory, this);
-        DocumentHostManager = new AsnDocumentHostManager(userSettings);
+        DocumentHostManager = documentHostManager;
+        TreeCommands = treeCommands;
         _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, TreeCommands, requestFileSave);
         GlobalData = new GlobalData();
         AppCommands = appCommands;
@@ -47,9 +47,7 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         DocumentHostManager.AddTab(new AsnDocumentHostVM(UserSettings, TreeCommands));
     }
 
-    async void OnUserSettingsChanged(Object sender, RequireTreeRefreshEventArgs args) {
-        await RefreshTabs(args.Filter);
-    }
+    
 
     public ICommand NewCommand { get; }
     public ICommand CloseTabCommand { get; }
@@ -183,9 +181,6 @@ class MainWindowVM : ViewModelBase, IMainWindowVM, IHasAsnDocumentTabs {
         }
     }
 
-    public Task RefreshTabs(Func<AsnTreeNode, Boolean>? filter = null) {
-        return Task.WhenAll(DocumentHostManager.Tabs.Select(x => x.GetPrimaryDocument().RefreshTreeView(filter)));
-    }
     public async Task RestoreSessionAsync(SessionRecoveryDto recoveryData) {
         if (recoveryData.Tabs.Count > 0) {
             DocumentHostManager.Clear();

--- a/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
+++ b/src/Asn1Editor/API/ViewModel/MainWindowVM.cs
@@ -25,19 +25,16 @@ class MainWindowVM : ViewModelBase, IMainWindowVM {
         AsnDocumentHostManager documentHostManager,
         ITreeCommands treeCommands,
         UserSettings userSettings) {
-        _windowFactory = windowFactory;
-        _uiMessenger = windowFactory.GetUIMessenger();
         UserSettings = userSettings;
         DocumentHostManager = documentHostManager;
         TreeCommands = treeCommands;
-        _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, TreeCommands, requestFileSave);
+        _windowFactory = windowFactory;
+        _uiMessenger = windowFactory.GetUIMessenger();
+        _documentFileService = new AsnDocumentFileService(_uiMessenger, DocumentHostManager, TreeCommands);
         GlobalData = new GlobalData();
         AppCommands = appCommands;
         
         NewCommand = new RelayCommand(_ => DocumentHostManager.AddNewTab(TreeCommands));
-        CloseTabCommand = new RelayCommand(closeTab, canCloseTab);
-        CloseAllTabsCommand = new RelayCommand(closeAllTabs);
-        CloseAllButThisTabCommand = new RelayCommand(closeAllButThisTab, canCloseAllButThisTab);
         OpenCommand = new AsyncCommand((_, _) => _documentFileService.OpenFileAsync());
         SaveCommand = new RelayCommand(o => _documentFileService.SaveFile(o as String), canPrintSave);
         ReloadDocumentCommand = new AsyncCommand((_, _) => _documentFileService.ReloadActiveDocumentAsync());
@@ -45,6 +42,10 @@ class MainWindowVM : ViewModelBase, IMainWindowVM {
         appCommands.ShowConverterWindow = new RelayCommand(showConverter);
         _sessionDocumentSource = new SessionDocumentSource(DocumentHostManager, UserSettings);
         DocumentHostManager.AddTab(new AsnDocumentHostVM(UserSettings, TreeCommands));
+
+        CloseTabCommand = new RelayCommand(closeTab, canCloseTab);
+        CloseAllTabsCommand = new RelayCommand(_ => CloseAllTabs());
+        CloseAllButThisTabCommand = new RelayCommand(closeAllButThis, canCloseAllButThisTab);
     }
 
     
@@ -73,16 +74,16 @@ class MainWindowVM : ViewModelBase, IMainWindowVM {
     /// </summary>
     /// <param name="o"></param>
     void showConverter(Object o) {
-        if (SelectedTab is null) {
+        if (DocumentHostManager.SelectedTab is null) {
             _windowFactory.ShowConverterWindow([], _documentFileService.OpenRawAsync);
         } else {
-            _windowFactory.ShowConverterWindow(SelectedTab.GetPrimaryDocument().AsnDocContext.RawData, _documentFileService.OpenRawAsync);
+            _windowFactory.ShowConverterWindow(DocumentHostManager.SelectedTab.GetPrimaryDocument().AsnDocContext.RawData, _documentFileService.OpenRawAsync);
         }
     }
 
     #region Write tab to file
     Boolean canPrintSave(Object obj) {
-        return SelectedTab?.Left.AsnDocContext.RawData.Count > 0;
+        return DocumentHostManager.SelectedTab?.Left.AsnDocContext.RawData.Count > 0;
     }
 
     Boolean requestFileSave(AsnDocumentHostVM tab) {
@@ -95,72 +96,30 @@ class MainWindowVM : ViewModelBase, IMainWindowVM {
     }
     #endregion
 
-    #region Close Tab(s)
+    #region Close Tab(s)/ Shutdown
 
     void closeTab(Object? o) {
-        if (o is AsnDocumentHostVM vm) {
-            closeTab(vm);
-        } else {
-            closeTab(SelectedTab);
-        }
+        DocumentHostManager.CloseTab(o as AsnDocumentHostVM ?? DocumentHostManager.SelectedTab, requestFileSave);
     }
+    void closeAllButThis(Object o) {
+        DocumentHostManager.CloseTabsWithPreservation(requestFileSave, o as AsnDocumentHostVM ?? DocumentHostManager.SelectedTab);
+    }
+    public Boolean CloseAllTabs() {
+        return DocumentHostManager.CloseTabsWithPreservation(requestFileSave);
+    }
+
     Boolean canCloseTab(Object? o) {
         return o is AsnDocumentHostVM or null;
-    }
-    void closeAllTabs(Object? o) {
-        CloseAllTabs();
-    }
-    void closeAllButThisTab(Object? o) {
-        if (o is AsnDocumentHostVM vm) {
-            closeTabsWithPreservation(vm);
-        } else {
-            closeTabsWithPreservation(SelectedTab);
-        }
     }
     Boolean canCloseAllButThisTab(Object? o) {
         if (DocumentHostManager.Tabs.Count == 0) {
             return false;
         }
         if (o is null) {
-            return SelectedTab is not null;
+            return DocumentHostManager.SelectedTab is not null;
         }
 
         return true;
-    }
-
-    void closeTab(AsnDocumentHostVM tab) {
-        Asn1DocumentVM doc = tab.GetPrimaryDocument();
-        if (!doc.IsModified) {
-            DocumentHostManager.RemoveTab(tab);
-        }
-        if (doc.IsModified && requestFileSave(tab)) {
-            DocumentHostManager.RemoveTab(tab);
-        }
-    }
-    Boolean closeTabsWithPreservation(AsnDocumentHostVM? preservedTab = null) {
-        // loop over a copy of tabs since we are going to update source collection in a loop
-        var tabs = DocumentHostManager.Tabs.ToList();
-        foreach (AsnDocumentHostVM tab in tabs) {
-            Asn1DocumentVM doc = tab.GetPrimaryDocument();
-            if (preservedTab is not null && Equals(tab, preservedTab)) {
-                continue;
-            }
-            if (!doc.IsModified) {
-                DocumentHostManager.RemoveTab(tab);
-
-                continue;
-            }
-            DocumentHostManager.SelectedTab = tab;
-            if (!requestFileSave(tab)) {
-                return false;
-            }
-            DocumentHostManager.RemoveTab(tab);
-        }
-
-        return true;
-    }
-    public Boolean CloseAllTabs() {
-        return closeTabsWithPreservation();
     }
 
     /// <inheritdoc />

--- a/src/Asn1Editor/API/ViewModel/OidEditorVM.cs
+++ b/src/Asn1Editor/API/ViewModel/OidEditorVM.cs
@@ -23,7 +23,7 @@ class OidEditorVM : ViewModelBase, IOidEditorVM {
     OidDto? selectedItem;
     OidSearchScope searchScope;
 
-    public OidEditorVM(IHasAsnDocumentTabs tabs, IOidDbManager oidMgr) {
+    public OidEditorVM(IHasAsnDocumentTabs tabs, IOidDbManager oidMgr, UserSettings userSettings) {
         _tabs = tabs;
         _oidMgr = oidMgr;
         ReloadCommand = new RelayCommand(reload);
@@ -37,7 +37,7 @@ class OidEditorVM : ViewModelBase, IOidEditorVM {
         OidView.Filter = filterOidList;
 
         SearchScope = OidSearchScope.UserDefined;
-        UserSettings = tabs.UserSettings;
+        UserSettings = userSettings;
     }
     Boolean filterOidList(Object obj) {
         if (obj is not OidDto entry) {

--- a/src/Asn1Editor/App.xaml.cs
+++ b/src/Asn1Editor/App.xaml.cs
@@ -79,11 +79,13 @@ public partial class App {
             // view models
             .RegisterSingleton<MainWindowVM>()
             .RegisterSingleton<IMainWindowVM, MainWindowVM>()
-            .RegisterType<IHasAsnDocumentTabs, MainWindowVM>()
+            .RegisterSingleton<AsnDocumentHostManager>()
+            .RegisterType<IHasAsnDocumentTabs, AsnDocumentHostManager>()
             .RegisterType<ITextViewerVM, TextViewerVM>()
             .RegisterType<IAsnValueEditorVM, AsnValueEditorVM>()
             .RegisterType<IOidEditorVM, OidEditorVM>()
             .RegisterType<INewAsnNodeEditorVM, NewAsnNodeEditorVM>()
+            .RegisterType<ITreeCommands, TreeViewCommands>()
             .RegisterInstance(_options);
         var oidMgr = new OidDbManager(Container.Resolve<IUIMessenger>()) {
             OidLookupLocations = [Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, _appDataPath]

--- a/src/Asn1Editor/Views/Resources/TabHeaderContextMenu.xaml
+++ b/src/Asn1Editor/Views/Resources/TabHeaderContextMenu.xaml
@@ -9,7 +9,7 @@
         <Setter Property="Command">
             <Setter.Value>
                 <Binding RelativeSource="{RelativeSource AncestorType=ContextMenu}"
-                         Path="PlacementTarget.Tag.SelectedTab.StartCompareModeCommand"/>
+                         Path="PlacementTarget.Tag.DocumentHostManager.SelectedTab.StartCompareModeCommand"/>
             </Setter.Value>
         </Setter>
 
@@ -45,7 +45,7 @@
         </MenuItem>
         <MenuItem Header="Synchronize Scrollbars"
                   IsCheckable="True"
-                  IsChecked="{Binding SelectedTab.IsScrollbarSynchronized}">
+                  IsChecked="{Binding DocumentHostManager.SelectedTab.IsScrollbarSynchronized}">
         </MenuItem>
         <Separator/>
         <MenuItem Header="_Close"

--- a/src/Asn1Editor/Views/Resources/TabHeaderContextMenu.xaml
+++ b/src/Asn1Editor/Views/Resources/TabHeaderContextMenu.xaml
@@ -40,7 +40,7 @@
         </MenuItem>
         <Separator/>
         <MenuItem Header="Compare with..."
-                  ItemsSource="{Binding Tabs}"
+                  ItemsSource="{Binding DocumentHostManager.Tabs}"
                   ItemContainerStyle="{StaticResource CompareMenuItemStyle}">
         </MenuItem>
         <MenuItem Header="Synchronize Scrollbars"

--- a/src/Asn1Editor/Views/UserControls/AppStatusBarUC.xaml
+++ b/src/Asn1Editor/Views/UserControls/AppStatusBarUC.xaml
@@ -8,32 +8,32 @@
     <StatusBar>
         <StatusBarItem>
             <TextBlock Text="Tag: ">
-                <Run Text="{Binding SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag, Mode=OneWay, StringFormat=0x{0:X2}}"/>
-                <Run Text="{Binding SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag, Mode=OneWay, StringFormat=(0)}"/>
+                <Run Text="{Binding DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag, Mode=OneWay, StringFormat=0x{0:X2}}"/>
+                <Run Text="{Binding DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag, Mode=OneWay, StringFormat=(0)}"/>
             </TextBlock>
         </StatusBarItem>
         <Separator/>
         <StatusBarItem>
             <TextBlock Text="Tag name: ">
-                <Run Text="{Binding  SelectedTab.Left.AsnDocContext.SelectedNode.Value.TagName, Mode=OneWay}"/>
+                <Run Text="{Binding  DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Value.TagName, Mode=OneWay}"/>
             </TextBlock>
         </StatusBarItem>
         <Separator/>
         <StatusBarItem>
             <TextBlock Text="Payload length: ">
-                <Run Text="{Binding  SelectedTab.Left.AsnDocContext.SelectedNode.Value.PayloadLength, Mode=OneWay}"/>
+                <Run Text="{Binding  DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Value.PayloadLength, Mode=OneWay}"/>
             </TextBlock>
         </StatusBarItem>
         <Separator/>
         <StatusBarItem>
             <TextBlock Text="Child nodes: ">
-                <Run Text="{Binding SelectedTab.Left.AsnDocContext.SelectedNode.Children.Count, Mode=OneWay}"/>
+                <Run Text="{Binding DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Children.Count, Mode=OneWay}"/>
             </TextBlock>
         </StatusBarItem>
         <Separator/>
         <StatusBarItem>
             <TextBlock Text="Size: ">
-                <Run Text="{Binding SelectedTab.Left.AsnDocContext.RawData.Count, Mode=OneWay}"/>
+                <Run Text="{Binding DocumentHostManager.SelectedTab.Left.AsnDocContext.RawData.Count, Mode=OneWay}"/>
                 <Run Text="bytes"/>
             </TextBlock>
         </StatusBarItem>

--- a/src/Asn1Editor/Views/UserControls/ClassicToolbarUC.xaml
+++ b/src/Asn1Editor/Views/UserControls/ClassicToolbarUC.xaml
@@ -103,7 +103,7 @@
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag}" Value="6">
+                                <DataTrigger Binding="{Binding DocumentHostManager.SelectedTab.Left.AsnDocContext.SelectedNode.Value.Tag}" Value="6">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                             </Style.Triggers>

--- a/src/Asn1Editor/Views/UserControls/DocumentTabsUC.xaml
+++ b/src/Asn1Editor/Views/UserControls/DocumentTabsUC.xaml
@@ -30,8 +30,8 @@
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-    <wpf:ClosableTabControl ItemsSource="{Binding Tabs}"
-                            SelectedItem="{Binding SelectedTab}"
+    <wpf:ClosableTabControl ItemsSource="{Binding DocumentHostManager.Tabs}"
+                            SelectedItem="{Binding DocumentHostManager.SelectedTab}"
                             AddTabCommand="{Binding NewCommand}"
                             CloseTabCommand="{Binding CloseTabCommand}"
                             ShowNewTabButton="False"


### PR DESCRIPTION
#### PR Classification
Design and code cleanup to centralize and simplify tab/document management.

#### PR Summary
This pull request introduces AsnDocumentHostManager to centralize ASN.1 document tab management and refactors related logic for improved maintainability and separation of concerns.
- Adds AsnDocumentHostManager class to handle all tab operations, removing tab logic from MainWindowVM.
- Refactors MainWindowVM to delegate tab management and file I/O to AsnDocumentHostManager and AsnDocumentFileService.
- Updates IHasAsnDocumentTabs interface and related ViewModels (AsnValueEditorVM, OidEditorVM) to receive UserSettings directly.
- Revises XAML bindings (DocumentTabsUC, TabHeaderContextMenu, AppStatusBarUC, ClassicToolbarUC) to use DocumentHostManager for tab data.
- Updates dependency injection and session management to use AsnDocumentHostManager.
