### PR TITLE
Changed the app WindowState from Normal to Maximized as default.

### DIFF
--- a/src/Asn1Editor/Views/Windows/MainWindow.xaml
+++ b/src/Asn1Editor/Views/Windows/MainWindow.xaml
@@ -11,6 +11,7 @@
         Title="ASN.1 Editor"
         Icon="/Views/Images/asnlogo.ico"
         WindowStartupLocation="CenterScreen"
+        WindowState="Maximized"
         Height="600"
         Width="800">
     <Window.InputBindings>


### PR DESCRIPTION
#### PR Classification
Design improvement to enhance user experience by adjusting the default window state.

#### PR Summary
The application window now opens maximized by default to provide a better initial user interface.
- MainWindow.xaml: Added the WindowState property and set it to "Maximized".
