### PR TITLE
Implemented TreeView node statuses and visual styles

### DIFF
--- a/src/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
+++ b/src/Asn1Editor/API/ViewModel/Asn1DocumentVM.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -76,6 +76,9 @@ public class Asn1DocumentVM : AsyncViewModel {
                 field = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(Header));
+                if (!field && AsnDocContext.Tree.Count > 0) {
+                    AsnDocContext.Tree[0].ResetMarkers();
+                }
             }
         }
     }

--- a/src/Asn1Editor/Views/Resources/TreeViewResources.xaml
+++ b/src/Asn1Editor/Views/Resources/TreeViewResources.xaml
@@ -123,15 +123,27 @@
                 <Border.Style>
                     <Style TargetType="Border">
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding Value.Status}" Value="Modified">
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Value.Status}" Value="Modified"/>
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="False"/>
+                                </MultiDataTrigger.Conditions>
                                 <Setter Property="Background" Value="#FFF3CD"/>
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding Value.Status}" Value="Added">
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Value.Status}" Value="Added"/>
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="False"/>
+                                </MultiDataTrigger.Conditions>
                                 <Setter Property="Background" Value="#D4EDDA"/>
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding Value.Status}" Value="Deleted">
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Value.Status}" Value="Deleted"/>
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="False"/>
+                                </MultiDataTrigger.Conditions>
                                 <Setter Property="Background" Value="#F8D7DA"/>
-                            </DataTrigger>
+                            </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
                 </Border.Style>

--- a/src/Asn1Editor/Views/Resources/TreeViewResources.xaml
+++ b/src/Asn1Editor/Views/Resources/TreeViewResources.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -109,16 +109,33 @@
                    Height="16"
                    Width="16"
                    Style="{StaticResource AsnTreeIconStyle}"/>
-            <TextBlock Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeView}}, Path=Foreground}"
-                       TextWrapping="NoWrap"
-                       Margin="5,0"
-                       behaviors:TextBlockBehavior.TrimLength="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeView}}, Path=MaxTextLength}"
-                       behaviors:TextBlockBehavior.SourceText="{Binding Value.Header, Mode=OneWay}">
-                <TextBlock.ToolTip>
-                    <TextBlock FontFamily="Consolas"
-                               Text="{Binding Value.ToolTip}"/>
-                </TextBlock.ToolTip>
-            </TextBlock>
+            <Border BorderThickness="0">
+                <TextBlock Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeView}}, Path=Foreground}"
+                           TextWrapping="NoWrap"
+                           Margin="5,0"
+                           behaviors:TextBlockBehavior.TrimLength="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeView}}, Path=MaxTextLength}"
+                           behaviors:TextBlockBehavior.SourceText="{Binding Value.Header, Mode=OneWay}">
+                    <TextBlock.ToolTip>
+                        <TextBlock FontFamily="Consolas"
+                                   Text="{Binding Value.ToolTip}"/>
+                    </TextBlock.ToolTip>
+                </TextBlock>
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Value.Status}" Value="Modified">
+                                <Setter Property="Background" Value="#FFF3CD"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Value.Status}" Value="Added">
+                                <Setter Property="Background" Value="#D4EDDA"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Value.Status}" Value="Deleted">
+                                <Setter Property="Background" Value="#F8D7DA"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
         </StackPanel>
     </HierarchicalDataTemplate>
     <Style x:Key="AsnTreeViewItemStyle" TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">

--- a/src/SysadminsLV.Asn1Editor.Core/Tree/AsnNodeStatus.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/Tree/AsnNodeStatus.cs
@@ -1,0 +1,23 @@
+namespace SysadminsLV.Asn1Editor.Core.Tree;
+
+/// <summary>
+/// Represents the status of a node in the ASN.1 tree structure.
+/// </summary>
+public enum AsnNodeStatus {
+    /// <summary>
+    /// The node has not been modified since it was last loaded or saved.
+    /// </summary>
+    Unchanged = 0,
+    /// <summary>
+    /// The node has been modified.
+    /// </summary>
+    Modified  = 1,
+    /// <summary>
+    /// The node has been newly added.
+    /// </summary>
+    Added     = 2,
+    /// <summary>
+    /// The child node has been deleted.
+    /// </summary>
+    Deleted   = 3
+}

--- a/src/SysadminsLV.Asn1Editor.Core/Tree/AsnNodeValue.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/Tree/AsnNodeValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -119,6 +119,27 @@ public class AsnNodeValue : NotifyPropertyChanged, IHexAsnNode {
         }
     }
     public String ExplicitValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the ASN.1 node, indicating whether the node has been 
+    /// modified, added, deleted, or remains unchanged.
+    /// </summary>
+    /// <value>
+    /// A <see cref="AsnNodeStatus"/> value representing the current state of the node.
+    /// </value>
+    /// <remarks>
+    /// The <see cref="Status"/> property is used to track changes to the node during 
+    /// editing operations. It can be set internally to reflect the node's state.
+    /// </remarks>
+    public AsnNodeStatus Status {
+        get;
+        internal set {
+            if (field != value) {
+                field = value;
+                OnPropertyChanged();
+            }
+        }
+    }
 
     /// <summary>
     /// Retrieves a formatted metadata string for the current ASN.1 node.

--- a/src/SysadminsLV.Asn1Editor.Core/Tree/AsnTreeNode.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/Tree/AsnTreeNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -184,6 +184,23 @@ public class AsnTreeNode {
     }
     public Task UpdateNodeHeaderAsync(Func<AsnTreeNode, Boolean>? filter = null) {
         return Task.Run(() => UpdateNodeView(filter));
+    }
+    /// <summary>
+    /// Resets the status markers for the current node and all its child nodes.
+    /// </summary>
+    /// <remarks>
+    /// This method traverses the tree starting from the current node, resetting the <see cref="AsnNodeValue.Status"/>
+    /// property of each node to <see cref="AsnNodeStatus.Unchanged"/>. It ensures that all nodes in the subtree
+    /// are marked as unmodified.
+    /// </remarks>
+    public void ResetMarkers() {
+        resetMarkers(this);
+    }
+    static void resetMarkers(AsnTreeNode node) {
+        node.Value.Status = AsnNodeStatus.Unchanged;
+        foreach (AsnTreeNode child in node.Children) {
+            resetMarkers(child);
+        }
     }
 
     void updateNodeView(AsnTreeNode node, Func<AsnTreeNode, Boolean>? filter) {

--- a/src/SysadminsLV.Asn1Editor.Core/Tree/TreeCoordinator.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/Tree/TreeCoordinator.cs
@@ -124,7 +124,9 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
     public async Task<AsnTreeNode> AddNode(Byte[] nodeRawData, AsnTreeNode? parent) {
         if (Root is null) {
             var asn = new Asn1Reader(nodeRawData);
-            var rootValue = new AsnNodeValue(asn);
+            var rootValue = new AsnNodeValue(asn) {
+                Status = AsnNodeStatus.Added
+            };
             Root = new AsnTreeNode(rootValue, _binarySource, viewOptions);
             _binarySource.InsertRange(0, nodeRawData);
             await Root.UpdateNodeHeaderAsync();
@@ -139,7 +141,11 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
         // create new node value from raw data
         var nodeValue = new AsnNodeValue(new Asn1Reader(nodeRawData));
         // create new node with the value and insert it into the binary source at the correct offset
-        var node = new AsnTreeNode(nodeValue, _binarySource, viewOptions);
+        var node = new AsnTreeNode(nodeValue, _binarySource, viewOptions) {
+            Value = {
+                        Status = AsnNodeStatus.Added
+                    }
+        };
         // shift the inserted node and its subtree to the end of the parent in the binary structure
         // it will not be updated by the propagation of size change
         node.UpdateOffset(parent.Value.Offset + parent.Value.TagLength);

--- a/src/SysadminsLV.Asn1Editor.Core/Tree/TreeCoordinator.cs
+++ b/src/SysadminsLV.Asn1Editor.Core/Tree/TreeCoordinator.cs
@@ -179,6 +179,10 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
         AsnTreeNode childNode = await AsnTreeBuilder.BuildTreeAsync(nodeRawData, _binarySource, viewOptions);
 
         _binarySource.InsertRange(binaryOffset, nodeRawData);
+        // mark all nodes in the inserted subtree as added
+        foreach (AsnTreeNode node in childNode.Flatten()) {
+            node.Value.Status = AsnNodeStatus.Added;
+        }
         parent.AddChildNode(childNode, insertIndex);
         // this has to be done before propagating size change, because the propagation relies
         // on the node's Path and MyIndex to update offsets of siblings
@@ -217,6 +221,7 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
 
         _binarySource.RemoveRange(nodeToRemove.Value.Offset, nodeLength);
         parent.RemoveChildNode(nodeToRemove);
+        parent.Value.Status = AsnNodeStatus.Deleted;
         // this has to be done before propagating size change, because the propagation relies
         // on the node's Path and MyIndex to update offsets of siblings
         updatePathsFrom(parent, nodeIndex);
@@ -253,6 +258,7 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
 
         // Parse the new encoded data to extract metadata
         var asn = new Asn1Reader(newData);
+        node.Value.Status = AsnNodeStatus.Modified;
 
         // Calculate size difference
         Int32 oldNodeSize = node.Value.TagLength;
@@ -282,6 +288,10 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
         Root!.UpdateNodeView();
     }
 
+    public void ResetMarkers() {
+        Root!.ResetMarkers();
+    }
+
     public void Reset() {
         Root = null;
         _binarySource.Clear();
@@ -309,7 +319,7 @@ public class TreeCoordinator(INodeViewOptions viewOptions) {
     /// <item>
     ///     Any increase in the length field size shifts the binary layout of:
     ///     <list type="bullet">
-    ///         <item>the node’s payload start offset,</item>
+    ///         <item>the nodeâ€™s payload start offset,</item>
     ///         <item>all nodes in its subtree,</item>
     ///         <item>and all following siblings in the parent node.</item>
     ///     </list>


### PR DESCRIPTION
#### PR Classification
New feature and UI enhancement to track and visualize ASN.1 node status changes.

#### PR Summary
This pull request adds status tracking for ASN.1 tree nodes and updates the UI to visually indicate node changes. It introduces a status property, updates logic for node operations, and enhances the tree view with color highlights.
- AsnNodeStatus enum and Status property added to AsnNodeValue for node state tracking.
- TreeCoordinator updates node statuses on insert, modify, and delete, and adds ResetMarkers for clearing statuses.
- AsnTreeNode implements recursive ResetMarkers to reset node and child statuses.
- TreeViewResources.xaml visually highlights nodes based on status using DataTriggers and background colors.


Here is an example:
<img width="584" height="235" alt="image" src="https://github.com/user-attachments/assets/6e16e078-8b43-420a-9ba7-6ccfe097e3e3" />
- yellow: means that the specific node was modified
- green: means that the node was added/inserted. All child nodes are automatically marked as inserted
- red: means that one more child nodes were removed. Deleted marker is set on a parent node whose child was removed.

On successful save, all markers are cleared.
